### PR TITLE
Add show method for character tables

### DIFF
--- a/src/CharTable.jl
+++ b/src/CharTable.jl
@@ -102,8 +102,12 @@ Omitting `x` will return the names of all importable character tables.
 
 # Examples
 ```jldoctest
-julia> g=genchartab(\"GL2\");
-
+julia> g = genchartab("GL2")
+Generic character table
+  of order q^4 - q^3 - q^2 + q
+  with 4 irreducible character types
+  with 4 class types
+  with parameters (i, j, l, k)
 ```
 """
 genchartab(x::String) = gentab(x, "Tables")
@@ -118,8 +122,12 @@ Omitting `x` will return the names of all importable greenfunctions.
 
 # Examples
 ```jldoctest
-julia> g=greenfuntab(\"GL2\");
-
+julia> g = greenfuntab("GL2")
+Generic character table
+  of order q^4 - q^3 - q^2 + q
+  with 2 irreducible character types
+  with 2 class types
+  without parameters
 ```
 """
 greenfuntab(x::String) = gentab(x, "Greenfunctions")

--- a/src/Show.jl
+++ b/src/Show.jl
@@ -1,6 +1,25 @@
 export chartypes, irrchartypes, classtypes, status, printinfotab, printval, printinfoclass, printinfochar, printclassparam, printcharparam, centord, chardeg, nrchars, nrclasses, nrparams, params
 # TODO PrintValPhi, PrintToTex?
 
+import Oscar: pretty, Indent
+
+function Base.show(io::IO, t::Table)
+    io = pretty(io)
+    println(io, "Generic character table", Indent())
+    println(io, "of order ", t.order)
+    c = congruence(t)
+    if c !== nothing
+        println(io, "restricted to q congruent to ", c[1], " modulo ", c[2])
+    end
+    println(io, "with ", irrchartypes(t)," irreducible character types")
+    println(io, "with ", classtypes(t)," class types")
+    if t isa SimpleCharTable
+        print(io, "without parameters")
+    else
+        print(io, "with parameters ", params(t)[2])
+    end
+end
+
 """
     chartypes(t::Table)
 
@@ -47,6 +66,10 @@ julia> classtypes(g)
 function classtypes(t::Table)
 	size(t.table, 2)
 end
+
+# TODO: document (and export) this?
+congruence(x::CharTable) = x.congruence
+congruence(x::SimpleCharTable) = nothing
 
 """
     status(t::Table)


### PR DESCRIPTION
Progress towards #14

Right now Green function tables are printed identically to "actual" generic character tables. Simply because there seems to be no way to actually distinguish the two after they have been loaded.