### PR TITLE
move `ParameterExceptions` to `CycloFrac` to improve printing

### DIFF
--- a/src/Arith.jl
+++ b/src/Arith.jl
@@ -154,12 +154,9 @@ struct CycloFrac{T} <: Cyclotomic{T}
 			elseif numerator == denominator
 				o=one(denominator)
 				return new{T}(o, o, exceptions)
-			else
-				return new{T}(numerator, denominator, exceptions)
 			end
-		else
-			return new{T}(numerator, denominator, exceptions)
 		end
+		return new{T}(numerator, denominator, exceptions)
 	end
 end
 
@@ -198,17 +195,18 @@ function Base.show(io::IO, z::CycloFrac)
 	end
 	if isone(length(z.numerator.summands))
 		if isone(length(z.denominator.summands))
-			print(io, "$(z.numerator)//$(z.denominator)$(exceptions)")
+			print(io, "$(z.numerator)//$(z.denominator)")
 		else
-			print(io, "$(z.numerator)//($(z.denominator))$(exceptions)")
+			print(io, "$(z.numerator)//($(z.denominator))")
 		end
 	else
 		if isone(length(z.denominator.summands))
-			print(io, "($(z.numerator))//$(z.denominator)$(exceptions)")
+			print(io, "($(z.numerator))//$(z.denominator)")
 		else
-			print(io, "($(z.numerator))//($(z.denominator))$(exceptions)")
+			print(io, "($(z.numerator))//($(z.denominator))")
 		end
 	end
+	print(io, exceptions)
 end
 Base.show(io::IO, m::MIME{Symbol("text/latex")}, z::CycloFrac) = print(io, "\\frac{$(repr("text/latex", z.numerator))}{$(repr("text/latex",z.denominator))}")
 Base.isone(x::CycloFrac) = isone(x.numerator) && isone(x.denominator)

--- a/src/Arith.jl
+++ b/src/Arith.jl
@@ -210,7 +210,18 @@ function Base.show(io::IO, z::CycloFrac)
 end
 Base.show(io::IO, m::MIME{Symbol("text/latex")}, z::CycloFrac) = print(io, "\\frac{$(repr("text/latex", z.numerator))}{$(repr("text/latex",z.denominator))}")
 Base.isone(x::CycloFrac) = isone(x.numerator) && isone(x.denominator)
-Base.iszero(x::CycloFrac) = iszero(x.numerator)  # TODO deal with exceptions?
+
+"""
+    iszero(x::CycloFrac; ignore_exceptions::Bool=false)
+
+Return if `x` is zero. If `ignore_exceptions` is true then the exceptions of `x` will not be considered.
+"""
+function Base.iszero(x::CycloFrac; ignore_exceptions::Bool=false)
+	if ignore_exceptions
+		return iszero(x.numerator)
+	end
+	return iszero(x.numerator) && isempty(x.exceptions)
+end
 
 # operators
 """
@@ -283,7 +294,7 @@ Base.:-(x::Cyclotomic{<:NfPoly}, y::Union{Int64, Rational{Int64}}) = x-(y*one(x)
 Base.:-(y::Cyclotomic) = (-1)*y
 
 Base.:(==)(x::CycloSum, y::CycloSum) = iszero(x-y)
-Base.:(==)(x::CycloFrac, y::CycloFrac) = iszero(x-y)  # TODO deal with exceptions?
+Base.:(==)(x::CycloFrac, y::CycloFrac) = iszero((x-y).numerator)
 
 function Base.:*(x::Cyclo, y::Cyclo)
 	if isone(x)

--- a/src/Arith.jl
+++ b/src/Arith.jl
@@ -162,9 +162,11 @@ struct CycloFrac{T} <: Cyclotomic{T}
 		end
 	end
 end
+
 function add_exception!(a::CycloFrac{T}, exception::ParameterException{T}) where T<:PolyRingElem
 	push!(a.exceptions, exception)
 end
+
 """
     shrink(a::CycloFrac{<:NfPoly})
 

--- a/src/Congruence.jl
+++ b/src/Congruence.jl
@@ -15,7 +15,7 @@ function setcongruence(x::CycloSum{T}, c::Union{T, Generic.FracFieldElem{T}}; si
 	CycloSum(summands, simplify=simplify)
 end
 function setcongruence(x::CycloFrac{T}, c::Union{T, Generic.FracFieldElem{T}}; simplify::Bool=true) where T <: NfPoly
-	CycloFrac(setcongruence(x.numerator, c), setcongruence(x.denominator, c), simplify=simplify)
+	CycloFrac(setcongruence(x.numerator, c), setcongruence(x.denominator, c), Set{ParameterException{T}}(setcongruence.(x.exceptions, Ref(c))), simplify=simplify)
 end
 function setcongruence(x::ParameterException{T}, c::Union{T, Generic.FracFieldElem{T}}; simplify::Bool=true) where T <: NfPoly
 	ParameterException(setcongruence(x.expression, c), simplify=simplify)

--- a/src/GenericCharacterTables.jl
+++ b/src/GenericCharacterTables.jl
@@ -19,8 +19,11 @@ module GenericCharacterTables
 using Oscar
 import Oscar.AbstractAlgebra.Generic
 
-include("Arith.jl")
+const FracPoly{T} = Generic.UnivPoly{Generic.FracFieldElem{T}, Generic.MPoly{Generic.FracFieldElem{T}}} where T
+const NfPoly = Union{PolyRingElem{QQFieldElem}, PolyRingElem{AbsSimpleNumFieldElem}}
+
 include("Parameter.jl")
+include("Arith.jl")
 include("CharTable.jl")
 include("Shifts.jl")
 include("SumProc.jl")

--- a/src/Shifts.jl
+++ b/src/Shifts.jl
@@ -18,7 +18,7 @@ function var_shift(a::CycloSum{<:NfPoly}, vars::Vector{Int64}, step_size::Int64,
 	return CycloSum(var_shift.(a.summands, Ref(vars), Ref(step_size), Ref(steps)),simplify=false)
 end
 function var_shift(a::CycloFrac{<:NfPoly}, vars::Vector{Int64}, step_size::Int64, steps::Int64)
-	return CycloFrac(var_shift(a.numerator, vars, step_size, steps), var_shift(a.denominator, vars, step_size, steps),simplify=false)
+	return CycloFrac(var_shift(a.numerator, vars, step_size, steps), var_shift(a.denominator, vars, step_size, steps), Set{ParameterException{T}}(var_shift(a.exceptions, Ref(vars), Ref(step_size), Ref(steps))), simplify=false)
 end
 function var_shift(a::Parameter{<:NfPoly}, vars::Vector{Int64}, step_size::Int64, steps::Int64)
 	return Parameter(var_shift(a.var, vars, step_size, steps), a.modulus)

--- a/src/Show.jl
+++ b/src/Show.jl
@@ -81,7 +81,7 @@ For example this excludes characters created with [`tensor!`](@ref) or [`lincomb
 julia> g=genchartab(\"GL2\");
 
 julia> nrirrchars(g)
-q^2 - 1
+q^2 - 1//1
 
 ```
 """
@@ -117,7 +117,7 @@ Return the number of conjugacy classes of table `t`.
 julia> g=genchartab(\"GL2\");
 
 julia> nrclasses(g)
-q^2 - 1
+q^2 - 1//1
 
 ```
 """
@@ -227,7 +227,7 @@ In the case of a `SimpleCharTable` this is always one.
 julia> g=genchartab(\"GL2\");
 
 julia> nrchars(g, 1)
-q - 1
+q - 1//1
 
 ```
 """
@@ -235,8 +235,8 @@ function nrchars(t::CharTable{T}, char::Int64) where T <: NfPoly
 	if char > irrchartypes(t)
 		throw(DomainError(char, "Cannot calculate number of characters in reducible types."))
 	else
-		result=simplify(t.charsums[char](e2p(t.argumentring(0))//e2p(t.argumentring(0)))[1], t)
-		return try_convert_to_real(result)
+		result=simplify(t.charsums[char](e2p(t.argumentring(0))//e2p(t.argumentring(0))), t)
+		return shrink(result)
 	end
 end
 function nrchars(t::SimpleCharTable, char::Int64)
@@ -256,7 +256,7 @@ Return the number of conjugacy classes in the class type `class` of the table `t
 julia> g=genchartab(\"GL2\");
 
 julia> nrclasses(g, 1)
-q - 1
+q - 1//1
 
 ```
 """
@@ -264,8 +264,8 @@ function nrclasses(t::CharTable{T}, class::Int64) where T <: NfPoly
 	if class > classtypes(t)
 		throw(DomainError(class, "Class type is out of range."))
 	end
-	result=simplify(t.classsums[class](e2p(t.argumentring(0))//e2p(t.argumentring(0)))[1], t)
-	return try_convert_to_real(result)
+	result=simplify(t.classsums[class](e2p(t.argumentring(0))//e2p(t.argumentring(0))), t)
+	return shrink(result)
 end
 function nrclasses(t::SimpleCharTable, class::Int64)
 	if class > classtypes(t)

--- a/src/Tables/2A2/GU3.jl
+++ b/src/Tables/2A2/GU3.jl
@@ -113,49 +113,49 @@ function (tt::Cyclotomic)
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [l], [k])
-	ss4,e1=nesum(tt, l, 0, q, congruence)
+	ss4=nesum(tt, l, 0, q, congruence)
 	ss5=ss4-tt1
-	ss5,e2=nesum(ss5, k, 0, q, congruence)
-	(ss5, union(e1,e2))
+	ss5=nesum(ss5, k, 0, q, congruence)
+	ss5
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [l], [k])
-	ss4,e1=nesum(tt, l, 0, q, congruence)
+	ss4=nesum(tt, l, 0, q, congruence)
 	ss5=ss4-tt1
-	ss5,e2=nesum(ss5, k, 0, q, congruence)
-	(ss5, union(e1,e2))
+	ss5=nesum(ss5, k, 0, q, congruence)
+	ss5
 end,
 function (tt::Cyclotomic)
-	ss6a,e1=nesum(tt, k, 0, q, congruence)
-	ss6b,e2=nesum(ss6a, l, 0, q, congruence)
-	ss6,e3=nesum(ss6b, m, 0, q, congruence)
+	ss6a=nesum(tt, k, 0, q, congruence)
+	ss6b=nesum(ss6a, l, 0, q, congruence)
+	ss6=nesum(ss6b, m, 0, q, congruence)
 	tt1=eesubs(tt, [l], [k])
-	ss7a,e4=nesum(tt1, k, 0, q, congruence)
-	ss7,e5=nesum(ss7a, m, 0, q, congruence)
+	ss7a=nesum(tt1, k, 0, q, congruence)
+	ss7=nesum(ss7a, m, 0, q, congruence)
 	tt2=eesubs(tt, [m], [l])
-	ss8a,e6=nesum(tt2, k, 0, q, congruence)
-	ss8,e7=nesum(ss8a, l, 0, q, congruence)
+	ss8a=nesum(tt2, k, 0, q, congruence)
+	ss8=nesum(ss8a, l, 0, q, congruence)
 	tt3=eesubs(tt, [m], [k])
-	ss9a,e8=nesum(tt3, k, 0, q, congruence)
-	ss9,e9=nesum(ss9a, l, 0, q, congruence)
+	ss9a=nesum(tt3, k, 0, q, congruence)
+	ss9=nesum(ss9a, l, 0, q, congruence)
 	tt4a=eesubs(tt, [l], [k])
 	tt4=eesubs(tt4a, [m], [k])
-	ss10,e10=nesum(tt4, k, 0, q, congruence)
-	(1//6*ss6-1//6*ss7-1//6*ss8-1//6*ss9+1//3*ss10, union(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10))
+	ss10=nesum(tt4, k, 0, q, congruence)
+	1//6*ss6-1//6*ss7-1//6*ss8-1//6*ss9+1//3*ss10
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, l, 0, q^2-2, congruence)
+	ss7=nesum(tt, l, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [l], [(q-1)*l])
-	ss8,e2=nesum(tt1, l, 0, q, congruence)
+	ss8=nesum(tt1, l, 0, q, congruence)
 	tt1=ss7-ss8
-	ss9,e3=nesum(tt1, k, 0, q, congruence)
-	(1//2*ss9, union(e1,e2,e3))
+	ss9=nesum(tt1, k, 0, q, congruence)
+	1//2*ss9
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, k, 0, q^3, congruence)
+	ss8=nesum(tt, k, 0, q^3, congruence)
 	tt1=eesubs(tt, [k], [(q^2-q+1)*k])
-	ss9,e2=nesum(tt1, k, 0, q, congruence)
-	(1//3*ss8-1//3*ss9, union(e1,e2))
+	ss9=nesum(tt1, k, 0, q, congruence)
+	1//3*ss8-1//3*ss9
 end
 ]
 
@@ -171,49 +171,49 @@ function (tt::Cyclotomic)
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [v], [u])
-	ss4,e1=nesum(tt, v, 0, q, congruence)
+	ss4=nesum(tt, v, 0, q, congruence)
 	ss5=ss4-tt1
-	ss5,e2=nesum(ss5, u, 0, q, congruence)
-	(ss5, union(e1,e2))
+	ss5=nesum(ss5, u, 0, q, congruence)
+	ss5
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [v], [u])
-	ss4,e1=nesum(tt, v, 0, q, congruence)
+	ss4=nesum(tt, v, 0, q, congruence)
 	ss5=ss4-tt1
-	ss5,e2=nesum(ss5, u, 0, q, congruence)
-	(ss5, union(e1,e2))
+	ss5=nesum(ss5, u, 0, q, congruence)
+	ss5
 end,
 function (tt::Cyclotomic)
-	ss6a,e1=nesum(tt, u, 0, q, congruence)
-	ss6b,e2=nesum(ss6a, v, 0, q, congruence)
-	ss6,e3=nesum(ss6b, w, 0, q, congruence)
+	ss6a=nesum(tt, u, 0, q, congruence)
+	ss6b=nesum(ss6a, v, 0, q, congruence)
+	ss6=nesum(ss6b, w, 0, q, congruence)
 	tt1=eesubs(tt, [v], [u])
-	ss7a,e4=nesum(tt1, u, 0, q, congruence)
-	ss7,e5=nesum(ss7a, w, 0, q, congruence)
+	ss7a=nesum(tt1, u, 0, q, congruence)
+	ss7=nesum(ss7a, w, 0, q, congruence)
 	tt2=eesubs(tt, [w], [v])
-	ss8a,e6=nesum(tt2, u, 0, q, congruence)
-	ss8,e7=nesum(ss8a, v, 0, q, congruence)
+	ss8a=nesum(tt2, u, 0, q, congruence)
+	ss8=nesum(ss8a, v, 0, q, congruence)
 	tt3=eesubs(tt, [w], [u])
-	ss9a,e8=nesum(tt3, u, 0, q, congruence)
-	ss9,e9=nesum(ss9a, v, 0, q, congruence)
+	ss9a=nesum(tt3, u, 0, q, congruence)
+	ss9=nesum(ss9a, v, 0, q, congruence)
 	tt4a=eesubs(tt, [v], [u])
 	tt4=eesubs(tt4a, [w], [u])
-	ss10,e10=nesum(tt4, u, 0, q, congruence)
-	(1//6*ss6-1//6*ss7-1//6*ss8-1//6*ss9+1//3*ss10, union(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10))
+	ss10=nesum(tt4, u, 0, q, congruence)
+	1//6*ss6-1//6*ss7-1//6*ss8-1//6*ss9+1//3*ss10
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, u, 0, q^2-2, congruence)
+	ss7=nesum(tt, u, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [u], [(q-1)*u])
-	ss8,e2=nesum(tt1, u, 0, q, congruence)
+	ss8=nesum(tt1, u, 0, q, congruence)
 	tt1=ss7-ss8
-	ss9,e3=nesum(tt1, v, 0, q, congruence)
-	(1//2*ss9, union(e1,e2,e3))
+	ss9=nesum(tt1, v, 0, q, congruence)
+	1//2*ss9
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, u, 0, q^3, congruence)
+	ss8=nesum(tt, u, 0, q^3, congruence)
 	tt1=eesubs(tt, [u], [(q^2-q+1)*u])
-	ss9,e2=nesum(tt1, u, 0, q, congruence)
-	(1//3*ss8-1//3*ss9, union(e1,e2))
+	ss9=nesum(tt1, u, 0, q, congruence)
+	1//3*ss8-1//3*ss9
 end
 ]
 

--- a/src/Tables/2A2/PGU3.2.jl
+++ b/src/Tables/2A2/PGU3.2.jl
@@ -123,16 +123,16 @@ chardegree = R.([1, q^2-q, q^3, q^2-q+1, q*(q^2-q+1), (q-1)*(q^2-q+1), q^3+1, (q
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
 	nesum(tt, k, 1, 2, congruence)
@@ -144,24 +144,24 @@ function (tt::Cyclotomic)
 	nesum(tt, k, 1, q, congruence)
 end,
 function (tt::Cyclotomic)
-	ss5a,e1=nesum(tt, k, 1, q, congruence)
-	ss5,e2=nesum(ss5a, l, 1, q, congruence)
+	ss5a=nesum(tt, k, 1, q, congruence)
+	ss5=nesum(ss5a, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [k])
-	ss6,e3=nesum(tt1, k, 1, q, congruence)
+	ss6=nesum(tt1, k, 1, q, congruence)
 	ss7=eesubs(tt, [k,l], S.([(q+1)*1//3,2*(q+1)*1//3]))
-	(1//6*ss5-1//6*ss6-1//3*ss7, union(e1,e2,e3))
+	1//6*ss5-1//6*ss6-1//3*ss7
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, k, 0, q^2-2, congruence)
+	ss7=nesum(tt, k, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	ss8,e2=nesum(tt1, k, 0, q, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, k, 0, q, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	ss10,e1=nesum(tt, k, 0, q^2-q, congruence)
+	ss10=nesum(tt, k, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [k], [(q^2-q+1)*1//3*k])
-	ss11,e2=nesum(tt1, k, 0, 2, congruence)
-	(1//3*ss10-1//3*ss11, union(e1,e2))
+	ss11=nesum(tt1, k, 0, 2, congruence)
+	1//3*ss10-1//3*ss11
 end
 ]
 
@@ -176,41 +176,41 @@ function (tt::Cyclotomic)
 	nesum(tt, u, 0, 2, congruence)
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, u, 1, q, congruence)
+	ss6=nesum(tt, u, 1, q, congruence)
 	tt1=eesubs(tt, [u], [(q+1)*1//3])
 	tt2=eesubs(tt, [u], [2*(q+1)*1//3])
-	(ss6-tt1-tt2, e1)
+	ss6-tt1-tt2
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, u, 1, q, congruence)
+	ss6=nesum(tt, u, 1, q, congruence)
 	tt1=eesubs(tt, [u], [(q+1)*1//3])
 	tt2=eesubs(tt, [u], [2*(q+1)*1//3])
-	(ss6-tt1-tt2, e1)
+	ss6-tt1-tt2
 end,
 function (tt::Cyclotomic)
-	ss5,e1=nesum(tt, u, 0, q, congruence)
-	ss8,e2=nesum(ss5, v, 0, q, congruence)
+	ss5=nesum(tt, u, 0, q, congruence)
+	ss8=nesum(ss5, v, 0, q, congruence)
 	tt1=eesubs(tt, [v], [-2*u])
-	ss9,e3=nesum(tt1, u, 0, q, congruence)
+	ss9=nesum(tt1, u, 0, q, congruence)
 	tt1=eesubs(tt, [u], [-2*v])
-	ss10,e4=nesum(tt1, v, 0, q, congruence)
+	ss10=nesum(tt1, v, 0, q, congruence)
 	tt1=eesubs(tt, [v], [u])
-	ss11,e5=nesum(tt1, u, 0, q, congruence)
+	ss11=nesum(tt1, u, 0, q, congruence)
 	tt1=eesubs(tt1, [u], [(q+1)*1//3*u])
-	ss12,e6=nesum(tt1, u, 0, 2, congruence)
-	(1//6*ss8-1//6*ss9-1//6*ss10-1//6*ss11+1//3*ss12, union(e1,e2,e3,e4,e5,e6))
+	ss12=nesum(tt1, u, 0, 2, congruence)
+	1//6*ss8-1//6*ss9-1//6*ss10-1//6*ss11+1//3*ss12
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, u, 0, q^2-2, congruence)
+	ss7=nesum(tt, u, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [u], [(q-1)*u])
-	ss8,e2=nesum(tt1, u, 0, q, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, u, 0, q, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	ss10,e1=nesum(tt, u, 0, q^2-q, congruence)
+	ss10=nesum(tt, u, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [u], [(q^2-q+1)*1//3*u])
-	ss11,e2=nesum(tt1, u, 0, 2, congruence)
-	(1//3*ss10-1//3*ss11, union(e1,e2))
+	ss11=nesum(tt1, u, 0, 2, congruence)
+	1//3*ss10-1//3*ss11
 end
 ]
 

--- a/src/Tables/2A2/PSU3.2.jl
+++ b/src/Tables/2A2/PSU3.2.jl
@@ -180,106 +180,106 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, a, 1, q, congruence)
+	ss6=nesum(tt, a, 1, q, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*1//3])
 	tt2=eesubs(tt, [a], [2*(q+1)*1//3])
-	(1//3*ss6-1//3*tt1-1//3*tt2, e1)
+	1//3*ss6-1//3*tt1-1//3*tt2
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, a, 1, q, congruence)
+	ss6=nesum(tt, a, 1, q, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*1//3])
 	tt2=eesubs(tt, [a], [2*(q+1)*1//3])
-	(1//3*ss6-1//3*tt1-1//3*tt2, e1)
+	1//3*ss6-1//3*tt1-1//3*tt2
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	ss5,e1=nesum(tt, a, 0, q, congruence)
-	ss8,e2=nesum(ss5, b, 0, q, congruence)
+	ss5=nesum(tt, a, 0, q, congruence)
+	ss8=nesum(ss5, b, 0, q, congruence)
 	tt1=eesubs(tt, [b], [a])
-	ss9,e3=nesum(tt1, a, 0, q, congruence)
+	ss9=nesum(tt1, a, 0, q, congruence)
 	tt2=eesubs(tt1, [a], [(q+1)*1//3*a])
-	ss10,e4=nesum(tt2, a, 0, 2, congruence)
+	ss10=nesum(tt2, a, 0, 2, congruence)
 	tt5=eesubs(tt, [b], [a+(q+1)*1//3])
 	tt4=eesubs(tt5, [a], [(q+1)*1//3*a])
-	ss11,e5=nesum(tt4, a, 0, 2, congruence)
-	(1//18*ss8-1//6*ss9+1//9*ss10-1//9*ss11, union(e1,e2,e3,e4,e5))
+	ss11=nesum(tt4, a, 0, 2, congruence)
+	1//18*ss8-1//6*ss9+1//9*ss10-1//9*ss11
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, a, 0, q^2-2, congruence)
+	ss7=nesum(tt, a, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	ss8,e2=nesum(tt1, a, 0, q, congruence)
-	(1//6*ss7-1//6*ss8, union(e1,e2))
+	ss8=nesum(tt1, a, 0, q, congruence)
+	1//6*ss7-1//6*ss8
 end,
 function (tt::Cyclotomic)
-	ss10,e1=nesum(tt, a, 0, q^2-q, congruence)
+	ss10=nesum(tt, a, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [a], [(q^2-q+1)*1//3*a])
-	ss11,e2=nesum(tt1, a, 0, 2, congruence)
-	(1//9*ss10-1//9*ss11, union(e1,e2))
+	ss11=nesum(tt1, a, 0, 2, congruence)
+	1//9*ss10-1//9*ss11
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
-end,
-function (tt::Cyclotomic)
-	nesum(tt, n, 1, (q-2)*1//3, congruence)
+	tt
 end,
 function (tt::Cyclotomic)
 	nesum(tt, n, 1, (q-2)*1//3, congruence)
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, n, 0, (q^2-4)*1//3, congruence)
+	nesum(tt, n, 1, (q-2)*1//3, congruence)
+end,
+function (tt::Cyclotomic)
+	ss7=nesum(tt, n, 0, (q^2-4)*1//3, congruence)
 	tt1=eesubs(tt, [n], [(q-1)*n])
-	ss8,e2=nesum(tt1, n, 0, (q-2)*1//3, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, n, 0, (q-2)*1//3, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	ss5a,e1=nesum(tt, m, 1, q, congruence)
-	ss5,e2=nesum(ss5a, n, 1, (q+1)*1//3, congruence)
+	ss5a=nesum(tt, m, 1, q, congruence)
+	ss5=nesum(ss5a, n, 1, (q+1)*1//3, congruence)
 	tt1=eesubs(tt, [n], [2*n])
 	tt2=eesubs(tt1, [m], [3*n])
-	ss6,e3=nesum(tt2, n, 1, (q-2)*1//3, congruence)
+	ss6=nesum(tt2, n, 1, (q-2)*1//3, congruence)
 	tt3=eesubs(tt, [m], [3*n])
-	ss8,e4=nesum(tt3, n, 1, (q-2)*1//3, congruence)
+	ss8=nesum(tt3, n, 1, (q-2)*1//3, congruence)
 	ss7=eesubs(tt, [m,n], [(q+1)*1//3,(q+1)*1//3])
-	(1//6*ss5-1//6*ss6-1//3*ss7-1//6*ss8, union(e1,e2,e3,e4))
+	1//6*ss5-1//6*ss6-1//3*ss7-1//6*ss8
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, n, 1, (q^2-q-2)*1//3, congruence)
-	(1//3*ss8, e1)
+	ss8=nesum(tt, n, 1, (q^2-q-2)*1//3, congruence)
+	1//3*ss8
 end
 ]
 

--- a/src/Tables/2A2/SU3.2.jl
+++ b/src/Tables/2A2/SU3.2.jl
@@ -254,102 +254,102 @@ function (tt::Cyclotomic)
 	nesum(tt, a, 0, 2, congruence)
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, a, 1, q, congruence)
+	ss6=nesum(tt, a, 1, q, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*1//3])
 	tt2=eesubs(tt, [a], [2*(q+1)*1//3])
-	(ss6-tt1-tt2, e1)
+	ss6-tt1-tt2
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, a, 1, q, congruence)
+	ss6=nesum(tt, a, 1, q, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*1//3])
 	tt2=eesubs(tt, [a], [2*(q+1)*1//3])
-	(ss6-tt1-tt2, e1)
+	ss6-tt1-tt2
 end,
 function (tt::Cyclotomic)
-	ss5,e1=nesum(tt, a, 0, q, congruence)
-	ss8,e2=nesum(ss5, b, 0, q, congruence)
+	ss5=nesum(tt, a, 0, q, congruence)
+	ss8=nesum(ss5, b, 0, q, congruence)
 	tt1=eesubs(tt, [b], [a])
-	ss9,e3=nesum(tt1, a, 0, q, congruence)
+	ss9=nesum(tt1, a, 0, q, congruence)
 	tt2=eesubs(tt1, [a], [(q+1)*1//3*a])
-	ss10,e4=nesum(tt2, a, 0, 2, congruence)
-	(1//6*ss8-1//2*ss9+1//3*ss10, union(e1,e2,e3,e4))
+	ss10=nesum(tt2, a, 0, 2, congruence)
+	1//6*ss8-1//2*ss9+1//3*ss10
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, a, 0, q^2-2, congruence)
+	ss7=nesum(tt, a, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	ss8,e2=nesum(tt1, a, 0, q, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, a, 0, q, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	ss10,e1=nesum(tt, a, 0, q^2-q, congruence)
+	ss10=nesum(tt, a, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [a], [(q^2-q+1)*1//3*a])
-	ss11,e2=nesum(tt1, a, 0, 2, congruence)
-	(1//3*ss10-1//3*ss11, union(e1,e2))
+	ss11=nesum(tt1, a, 0, 2, congruence)
+	1//3*ss10-1//3*ss11
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
-end,
-function (tt::Cyclotomic)
-	nesum(tt, n, 1, q, congruence)
+	tt
 end,
 function (tt::Cyclotomic)
 	nesum(tt, n, 1, q, congruence)
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, n, 0, q^2-2, congruence)
+	nesum(tt, n, 1, q, congruence)
+end,
+function (tt::Cyclotomic)
+	ss7=nesum(tt, n, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [n], [(q-1)*n])
-	ss8,e2=nesum(tt1, n, 0, q, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, n, 0, q, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	ss5a,e1=nesum(tt, n, 1, q, congruence)
-	ss5,e2=nesum(ss5a, m, 1, q, congruence)
+	ss5a=nesum(tt, n, 1, q, congruence)
+	ss5=nesum(ss5a, m, 1, q, congruence)
 	tt1=eesubs(tt, [m], [n])
-	ss6,e3=nesum(tt1, n, 1, q, congruence)
+	ss6=nesum(tt1, n, 1, q, congruence)
 	ss7=eesubs(tt, [m,n], [(q+1)*1//3,2*(q+1)*1//3])
-	(1//6*ss5-1//6*ss6-1//3*ss7, union(e1,e2,e3))
+	1//6*ss5-1//6*ss6-1//3*ss7
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, n, 0, q^2-q, congruence)
+	ss8=nesum(tt, n, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [n], [(q^2-q+1)*1//3*n])
-	ss9,e2=nesum(tt1, n, 0, 2, congruence)
-	(1//3*ss8-1//3*ss9, union(e1,e2))
+	ss9=nesum(tt1, n, 0, 2, congruence)
+	1//3*ss8-1//3*ss9
 end
 ]
 

--- a/src/Tables/2A2/SU3.n2.jl
+++ b/src/Tables/2A2/SU3.n2.jl
@@ -103,72 +103,72 @@ chardegree = R.([1, q^2-q, q^3, q^2-q+1, q*(q^2-q+1), (q-1)*(q^2-q+1), (q+1)*(q^
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
-end,
-function (tt::Cyclotomic)
-	nesum(tt, a, 1, q, congruence)
+	tt
 end,
 function (tt::Cyclotomic)
 	nesum(tt, a, 1, q, congruence)
 end,
 function (tt::Cyclotomic)
-	ss5,e1=nesum(tt, a, 0, q, congruence)
-	ss6,e2=nesum(ss5, b, 0, q, congruence)
+	nesum(tt, a, 1, q, congruence)
+end,
+function (tt::Cyclotomic)
+	ss5=nesum(tt, a, 0, q, congruence)
+	ss6=nesum(ss5, b, 0, q, congruence)
 	tt1=eesubs(tt, [b], [a])
-	ss7,e3=nesum(tt1, a, 0, q, congruence)
+	ss7=nesum(tt1, a, 0, q, congruence)
 	tt2=eesubs(tt1, [a], [0])
-	(1//6*ss6-1//2*ss7+1//3*tt2, union(e1,e2,e3))
+	1//6*ss6-1//2*ss7+1//3*tt2
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, a, 0, q^2-2, congruence)
+	ss7=nesum(tt, a, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	ss8,e2=nesum(tt1, a, 0, q, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, a, 0, q, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, a, 1, q^2-q, congruence)
-	(1//3*ss8, e1)
+	ss8=nesum(tt, a, 1, q^2-q, congruence)
+	1//3*ss8
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
-end,
-function (tt::Cyclotomic)
-	nesum(tt, n, 1, q, congruence)
+	tt
 end,
 function (tt::Cyclotomic)
 	nesum(tt, n, 1, q, congruence)
 end,
 function (tt::Cyclotomic)
-	ss5,e1=nesum(tt, n, 1, q, congruence)
-	ss6,e2=nesum(ss5, m, 1, q, congruence)
+	nesum(tt, n, 1, q, congruence)
+end,
+function (tt::Cyclotomic)
+	ss5=nesum(tt, n, 1, q, congruence)
+	ss6=nesum(ss5, m, 1, q, congruence)
 	tt1=eesubs(tt, [m], [n])
-	ss7,e3=nesum(tt1, n, 1, q, congruence)
-	(1//6*ss6-1//6*ss7, union(e1,e2,e3))
+	ss7=nesum(tt1, n, 1, q, congruence)
+	1//6*ss6-1//6*ss7
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, n, 0, q^2-2, congruence)
+	ss7=nesum(tt, n, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [n], [(q-1)*n])
-	ss8,e2=nesum(tt1, n, 0, q, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, n, 0, q, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, n, 1, q^2-q, congruence)
-	(1//3*ss8, e1)
+	ss8=nesum(tt, n, 1, q^2-q, congruence)
+	1//3*ss8
 end
 ]
 

--- a/src/Tables/2B2/2B2.jl
+++ b/src/Tables/2B2/2B2.jl
@@ -86,55 +86,55 @@ chardegree = R.([1, q*1//sqrt2*(q^2-1), q*1//sqrt2*(q^2-1), q^4, q^4+1, (q^2-1)*
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, b, 1, q^2+sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, b, 1, q^2+sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, c, 1, q^2-sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, c, 1, q^2-sqrt2*q, congruence)
+	1//4*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, s, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, s, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, k, 1, q^2+sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, u, 1, q^2-sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, u, 1, q^2-sqrt2*q, congruence)
+	1//4*s1
 end
 ]
 

--- a/src/Tables/2F4/2F4.1.jl
+++ b/src/Tables/2F4/2F4.1.jl
@@ -2293,438 +2293,438 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	s2,e2=nesum(s1, b, 1, q^2-2, congruence)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	s2=nesum(s1, b, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s3,e3=nesum(tt1, a, 1, q^2-2, congruence)
+	s3=nesum(tt1, a, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [b], [-a])
-	s4,e4=nesum(tt1, a, 1, q^2-2, congruence)
+	s4=nesum(tt1, a, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [-(q*sqrt2-1)*b])
-	s5,e5=nesum(tt1, b, 1, q^2-2, congruence)
+	s5=nesum(tt1, b, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [(q*sqrt2-1)*b])
-	s6,e6=nesum(tt1, b, 1, q^2-2, congruence)
+	s6=nesum(tt1, b, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [b], [-(q*sqrt2-1)*a])
-	s7,e7=nesum(tt1, a, 1, q^2-2, congruence)
+	s7=nesum(tt1, a, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [b], [(q*sqrt2-1)*a])
-	s8,e8=nesum(tt1, a, 1, q^2-2, congruence)
-	(1//16*s2-1//16*s3-1//16*s4-1//16*s5-1//16*s6-1//16*s7-1//16*s8, union(e1,e2,e3,e4,e5,e6,e7,e8))
+	s8=nesum(tt1, a, 1, q^2-2, congruence)
+	1//16*s2-1//16*s3-1//16*s4-1//16*s5-1//16*s6-1//16*s7-1//16*s8
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2, congruence)
+	s1=nesum(tt, a, 1, q^2, congruence)
 	s2=eesubs(tt, [a], [(q^2+1)*1//3])
 	s3=eesubs(tt, [a], [2*(q^2+1)*1//3])
-	(1//2*s1-1//2*s2-1//2*s3, e1)
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2, congruence)
+	s1=nesum(tt, a, 1, q^2, congruence)
 	s2=eesubs(tt, [a], [(q^2+1)*1//3])
 	s3=eesubs(tt, [a], [2*(q^2+1)*1//3])
-	(1//2*s1-1//2*s2-1//2*s3, e1)
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-2, congruence)
+	s1=nesum(tt, a, 1, q^4-2, congruence)
 	tt1=eesubs(tt, [a], [(q^2-1)*a])
-	s2,e2=nesum(tt1, a, 1, q^2, congruence)
+	s2=nesum(tt1, a, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [(q^2+1)*a])
-	s3,e3=nesum(tt1, a, 1, q^2-2, congruence)
-	(1//4*s1-1//4*s2-1//4*s3, union(e1,e2,e3))
+	s3=nesum(tt1, a, 1, q^2-2, congruence)
+	1//4*s1-1//4*s2-1//4*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-sqrt2*q^3+sqrt2*q-2, congruence)
+	s1=nesum(tt, a, 1, q^4-sqrt2*q^3+sqrt2*q-2, congruence)
 	tt1=eesubs(tt, [a], [(q^2-1)*a])
-	s2,e2=nesum(tt1, a, 1, q^2-sqrt2*q, congruence)
+	s2=nesum(tt1, a, 1, q^2-sqrt2*q, congruence)
 	tt1=eesubs(tt, [a], [(q^2-sqrt2*q+1)*a])
-	s3,e3=nesum(tt1, a, 1, q^2-2, congruence)
-	(1//8*s1-1//8*s2-1//8*s3, union(e1,e2,e3))
+	s3=nesum(tt1, a, 1, q^2-2, congruence)
+	1//8*s1-1//8*s2-1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4+sqrt2*q^3-sqrt2*q-2, congruence)
+	s1=nesum(tt, a, 1, q^4+sqrt2*q^3-sqrt2*q-2, congruence)
 	tt1=eesubs(tt, [a], [(q^2-1)*a])
-	s2,e2=nesum(tt1, a, 1, q^2+sqrt2*q, congruence)
+	s2=nesum(tt1, a, 1, q^2+sqrt2*q, congruence)
 	tt1=eesubs(tt, [a], [(q^2+sqrt2*q+1)*a])
-	s3,e3=nesum(tt1, a, 1, q^2-2, congruence)
-	(1//8*s1-1//8*s2-1//8*s3, union(e1,e2,e3))
+	s3=nesum(tt1, a, 1, q^2-2, congruence)
+	1//8*s1-1//8*s2-1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
-	s2,e2=nesum(s1, b, 1, q^2+sqrt2*q, congruence)
-	(1//16*s2, union(e1,e2))
+	s1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
+	s2=nesum(s1, b, 1, q^2+sqrt2*q, congruence)
+	1//16*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, (q^2-sqrt2*q-4)*(q^2-sqrt2*q), congruence)
-	(1//96*s1, e1)
+	s1=nesum(tt, a, 1, (q^2-sqrt2*q-4)*(q^2-sqrt2*q), congruence)
+	1//96*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, (q^2+sqrt2*q-4)*(q^2+sqrt2*q), congruence)
-	(1//96*s1, e1)
+	s1=nesum(tt, a, 1, (q^2+sqrt2*q-4)*(q^2+sqrt2*q), congruence)
+	1//96*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2, congruence)
-	s2,e2=nesum(s1, b, 1, q^2, congruence)
+	s1=nesum(tt, a, 1, q^2, congruence)
+	s2=nesum(s1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [b])
-	s3,e3=nesum(tt1, b, 1, q^2, congruence)
+	s3=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [-b])
-	s4,e4=nesum(tt1, b, 1, q^2, congruence)
+	s4=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [(q*sqrt2-1)*b])
-	s5,e5=nesum(tt1, b, 1, q^2, congruence)
+	s5=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [-(q*sqrt2-1)*b])
-	s6,e6=nesum(tt1, b, 1, q^2, congruence)
+	s6=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [(q*sqrt2+1)*b])
-	s7,e7=nesum(tt1, b, 1, q^2, congruence)
+	s7=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [-(q*sqrt2+1)*b])
-	s8,e8=nesum(tt1, b, 1, q^2, congruence)
+	s8=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [b], [(q*sqrt2-1)*a])
-	s9,e9=nesum(tt1, a, 1, q^2, congruence)
+	s9=nesum(tt1, a, 1, q^2, congruence)
 	tt1=eesubs(tt, [b], [-(q*sqrt2-1)*a])
-	s10,e10=nesum(tt1, a, 1, q^2, congruence)
+	s10=nesum(tt1, a, 1, q^2, congruence)
 	tt1=eesubs(tt, [b], [(q*sqrt2+1)*a])
-	s11,e11=nesum(tt1, a, 1, q^2, congruence)
+	s11=nesum(tt1, a, 1, q^2, congruence)
 	tt1=eesubs(tt, [b], [-(q*sqrt2+1)*a])
-	s12,e12=nesum(tt1, a, 1, q^2, congruence)
+	s12=nesum(tt1, a, 1, q^2, congruence)
 	s13=eesubs(tt, [a,b], S.([b,(q^2+1)*1//3]))
 	s14=eesubs(tt, [a,b], S.([-b,(q^2+1)*1//3]))
 	s15=eesubs(tt, [a,b], S.([b,2*(q^2+1)*1//3]))
 	s16=eesubs(tt, [a,b], S.([-b,2*(q^2+1)*1//3]))
-	(1//48*s2-1//48*s3-1//48*s4-1//48*s5-1//48*s6-1//48*s7-1//48*s8-1//48*s9-1//48*s10-1//48*s11-1//48*s12+1//12*s13+1//12*s14+1//12*s15+1//12*s16, union(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12))
+	1//48*s2-1//48*s3-1//48*s4-1//48*s5-1//48*s6-1//48*s7-1//48*s8-1//48*s9-1//48*s10-1//48*s11-1//48*s12+1//12*s13+1//12*s14+1//12*s15+1//12*s16
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-q^2, congruence)
+	s1=nesum(tt, a, 1, q^4-q^2, congruence)
 	s2=eesubs(tt, [a], [(q^4-q^2+1)*1//3])
 	s3=eesubs(tt, [a], [2*(q^4-q^2+1)*1//3])
-	(1//6*s1-1//6*s2-1//6*s3, e1)
+	1//6*s1-1//6*s2-1//6*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-sqrt2*q^3+q^2-sqrt2*q, congruence)
-	(1//12*s1, e1)
+	s1=nesum(tt, a, 1, q^4-sqrt2*q^3+q^2-sqrt2*q, congruence)
+	1//12*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4+sqrt2*q^3+q^2+sqrt2*q, congruence)
-	(1//12*s1, e1)
+	s1=nesum(tt, a, 1, q^4+sqrt2*q^3+q^2+sqrt2*q, congruence)
+	1//12*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	s2,e2=nesum(s1, l, 1, q^2-2, congruence)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	s2=nesum(s1, l, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [l], [k])
-	s3,e3=nesum(tt1, k, 1, q^2-2, congruence)
+	s3=nesum(tt1, k, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [l], [-k])
-	s4,e4=nesum(tt1, k, 1, q^2-2, congruence)
+	s4=nesum(tt1, k, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [k], [-(q*sqrt2-1)*l])
-	s5,e5=nesum(tt1, l, 1, q^2-2, congruence)
+	s5=nesum(tt1, l, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [k], [(q*sqrt2-1)*l])
-	s6,e6=nesum(tt1, l, 1, q^2-2, congruence)
+	s6=nesum(tt1, l, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [l], [-(q*sqrt2-1)*k])
-	s7,e7=nesum(tt1, k, 1, q^2-2, congruence)
+	s7=nesum(tt1, k, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [l], [(q*sqrt2-1)*k])
-	s8,e8=nesum(tt1, k, 1, q^2-2, congruence)
-	(1//16*s2-1//16*s3-1//16*s4-1//16*s5-1//16*s6-1//16*s7-1//16*s8, union(e1,e2,e3,e4,e5,e6,e7,e8))
+	s8=nesum(tt1, k, 1, q^2-2, congruence)
+	1//16*s2-1//16*s3-1//16*s4-1//16*s5-1//16*s6-1//16*s7-1//16*s8
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2, congruence)
+	s1=nesum(tt, k, 1, q^2, congruence)
 	s2=eesubs(tt, [k], [(q^2+1)*1//3])
 	s3=eesubs(tt, [k], [2*(q^2+1)*1//3])
-	(1//2*s1-1//2*s2-1//2*s3, e1)
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2, congruence)
+	s1=nesum(tt, k, 1, q^2, congruence)
 	s2=eesubs(tt, [k], [(q^2+1)*1//3])
 	s3=eesubs(tt, [k], [2*(q^2+1)*1//3])
-	(1//2*s1-1//2*s2-1//2*s3, e1)
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-2, congruence)
+	s1=nesum(tt, k, 1, q^4-2, congruence)
 	tt1=eesubs(tt, [k], [(q^2-1)*k])
-	s2,e2=nesum(tt1, k, 1, q^2, congruence)
+	s2=nesum(tt1, k, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [(q^2+1)*k])
-	s3,e3=nesum(tt1, k, 1, q^2-2, congruence)
-	(1//4*s1-1//4*s2-1//4*s3, union(e1,e2,e3))
+	s3=nesum(tt1, k, 1, q^2-2, congruence)
+	1//4*s1-1//4*s2-1//4*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-sqrt2*q^3+sqrt2*q-2, congruence)
+	s1=nesum(tt, k, 1, q^4-sqrt2*q^3+sqrt2*q-2, congruence)
 	tt1=eesubs(tt, [k], [(q^2-1)*k])
-	s2,e2=nesum(tt1, k, 1, q^2-sqrt2*q, congruence)
+	s2=nesum(tt1, k, 1, q^2-sqrt2*q, congruence)
 	tt1=eesubs(tt, [k], [(q^2-sqrt2*q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q^2-2, congruence)
-	(1//8*s1-1//8*s2-1//8*s3, union(e1,e2,e3))
+	s3=nesum(tt1, k, 1, q^2-2, congruence)
+	1//8*s1-1//8*s2-1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4+sqrt2*q^3-sqrt2*q-2, congruence)
+	s1=nesum(tt, k, 1, q^4+sqrt2*q^3-sqrt2*q-2, congruence)
 	tt1=eesubs(tt, [k], [(q^2-1)*k])
-	s2,e2=nesum(tt1, k, 1, q^2+sqrt2*q, congruence)
+	s2=nesum(tt1, k, 1, q^2+sqrt2*q, congruence)
 	tt1=eesubs(tt, [k], [(q^2+sqrt2*q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q^2-2, congruence)
-	(1//8*s1-1//8*s2-1//8*s3, union(e1,e2,e3))
+	s3=nesum(tt1, k, 1, q^2-2, congruence)
+	1//8*s1-1//8*s2-1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-sqrt2*q, congruence)
-	s2,e2=nesum(s1, l, 1, q^2+sqrt2*q, congruence)
-	(1//16*s2, union(e1,e2))
+	s1=nesum(tt, k, 1, q^2-sqrt2*q, congruence)
+	s2=nesum(s1, l, 1, q^2+sqrt2*q, congruence)
+	1//16*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2, congruence)
-	s2,e2=nesum(s1, l, 1, q^2, congruence)
+	s1=nesum(tt, k, 1, q^2, congruence)
+	s2=nesum(s1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q^2, congruence)
+	s3=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s4,e4=nesum(tt1, l, 1, q^2, congruence)
+	s4=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [(q*sqrt2-1)*l])
-	s5,e5=nesum(tt1, l, 1, q^2, congruence)
+	s5=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [-(q*sqrt2-1)*l])
-	s6,e6=nesum(tt1, l, 1, q^2, congruence)
+	s6=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [(q*sqrt2+1)*l])
-	s7,e7=nesum(tt1, l, 1, q^2, congruence)
+	s7=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [-(q*sqrt2+1)*l])
-	s8,e8=nesum(tt1, l, 1, q^2, congruence)
+	s8=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [l], [(q*sqrt2-1)*k])
-	s9,e9=nesum(tt1, k, 1, q^2, congruence)
+	s9=nesum(tt1, k, 1, q^2, congruence)
 	tt1=eesubs(tt, [l], [-(q*sqrt2-1)*k])
-	s10,e10=nesum(tt1, k, 1, q^2, congruence)
+	s10=nesum(tt1, k, 1, q^2, congruence)
 	tt1=eesubs(tt, [l], [(q*sqrt2+1)*k])
-	s11,e11=nesum(tt1, k, 1, q^2, congruence)
+	s11=nesum(tt1, k, 1, q^2, congruence)
 	tt1=eesubs(tt, [l], [-(q*sqrt2+1)*k])
-	s12,e12=nesum(tt1, k, 1, q^2, congruence)
+	s12=nesum(tt1, k, 1, q^2, congruence)
 	s13=eesubs(tt, [k,l], S.([l,(q^2+1)*1//3]))
 	s14=eesubs(tt, [k,l], S.([-l,(q^2+1)*1//3]))
 	s15=eesubs(tt, [k,l], S.([l,2*(q^2+1)*1//3]))
 	s16=eesubs(tt, [k,l], S.([-l,2*(q^2+1)*1//3]))
-	(1//48*s2-1//48*s3-1//48*s4-1//48*s5-1//48*s6-1//48*s7-1//48*s8-1//48*s9-1//48*s10-1//48*s11-1//48*s12+1//12*s13+1//12*s14+1//12*s15+1//12*s16, union(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12))
+	1//48*s2-1//48*s3-1//48*s4-1//48*s5-1//48*s6-1//48*s7-1//48*s8-1//48*s9-1//48*s10-1//48*s11-1//48*s12+1//12*s13+1//12*s14+1//12*s15+1//12*s16
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-q^2, congruence)
+	s1=nesum(tt, k, 1, q^4-q^2, congruence)
 	s2=eesubs(tt, [k], [(q^4-q^2+1)*1//3])
 	s3=eesubs(tt, [k], [2*(q^4-q^2+1)*1//3])
-	(1//6*s1-1//6*s2-1//6*s3, e1)
+	1//6*s1-1//6*s2-1//6*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-sqrt2*q^3+q^2-sqrt2*q, congruence)
-	(1//12*s1, e1)
+	s1=nesum(tt, k, 1, q^4-sqrt2*q^3+q^2-sqrt2*q, congruence)
+	1//12*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4+sqrt2*q^3+q^2+sqrt2*q, congruence)
-	(1//12*s1, e1)
+	s1=nesum(tt, k, 1, q^4+sqrt2*q^3+q^2+sqrt2*q, congruence)
+	1//12*s1
 end
 ]
 

--- a/src/Tables/2F4/2F4.2.jl
+++ b/src/Tables/2F4/2F4.2.jl
@@ -2293,438 +2293,438 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-2, congruence)
-	s2,e2=nesum(s1, b, 1, q^2-2, congruence)
+	s1=nesum(tt, a, 1, q^2-2, congruence)
+	s2=nesum(s1, b, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s3,e3=nesum(tt1, a, 1, q^2-2, congruence)
+	s3=nesum(tt1, a, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [b], [-a])
-	s4,e4=nesum(tt1, a, 1, q^2-2, congruence)
+	s4=nesum(tt1, a, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [-(q*sqrt2-1)*b])
-	s5,e5=nesum(tt1, b, 1, q^2-2, congruence)
+	s5=nesum(tt1, b, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [(q*sqrt2-1)*b])
-	s6,e6=nesum(tt1, b, 1, q^2-2, congruence)
+	s6=nesum(tt1, b, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [b], [-(q*sqrt2-1)*a])
-	s7,e7=nesum(tt1, a, 1, q^2-2, congruence)
+	s7=nesum(tt1, a, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [b], [(q*sqrt2-1)*a])
-	s8,e8=nesum(tt1, a, 1, q^2-2, congruence)
-	(1//16*s2-1//16*s3-1//16*s4-1//16*s5-1//16*s6-1//16*s7-1//16*s8, union(e1,e2,e3,e4,e5,e6,e7,e8))
+	s8=nesum(tt1, a, 1, q^2-2, congruence)
+	1//16*s2-1//16*s3-1//16*s4-1//16*s5-1//16*s6-1//16*s7-1//16*s8
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2, congruence)
+	s1=nesum(tt, a, 1, q^2, congruence)
 	s2=eesubs(tt, [a], [(q^2+1)*1//3])
 	s3=eesubs(tt, [a], [2*(q^2+1)*1//3])
-	(1//2*s1-1//2*s2-1//2*s3, e1)
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2, congruence)
+	s1=nesum(tt, a, 1, q^2, congruence)
 	s2=eesubs(tt, [a], [(q^2+1)*1//3])
 	s3=eesubs(tt, [a], [2*(q^2+1)*1//3])
-	(1//2*s1-1//2*s2-1//2*s3, e1)
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-2, congruence)
+	s1=nesum(tt, a, 1, q^4-2, congruence)
 	tt1=eesubs(tt, [a], [(q^2-1)*a])
-	s2,e2=nesum(tt1, a, 1, q^2, congruence)
+	s2=nesum(tt1, a, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [(q^2+1)*a])
-	s3,e3=nesum(tt1, a, 1, q^2-2, congruence)
-	(1//4*s1-1//4*s2-1//4*s3, union(e1,e2,e3))
+	s3=nesum(tt1, a, 1, q^2-2, congruence)
+	1//4*s1-1//4*s2-1//4*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-sqrt2*q^3+sqrt2*q-2, congruence)
+	s1=nesum(tt, a, 1, q^4-sqrt2*q^3+sqrt2*q-2, congruence)
 	tt1=eesubs(tt, [a], [(q^2-1)*a])
-	s2,e2=nesum(tt1, a, 1, q^2-sqrt2*q, congruence)
+	s2=nesum(tt1, a, 1, q^2-sqrt2*q, congruence)
 	tt1=eesubs(tt, [a], [(q^2-sqrt2*q+1)*a])
-	s3,e3=nesum(tt1, a, 1, q^2-2, congruence)
-	(1//8*s1-1//8*s2-1//8*s3, union(e1,e2,e3))
+	s3=nesum(tt1, a, 1, q^2-2, congruence)
+	1//8*s1-1//8*s2-1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^2+sqrt2*q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4+sqrt2*q^3-sqrt2*q-2, congruence)
+	s1=nesum(tt, a, 1, q^4+sqrt2*q^3-sqrt2*q-2, congruence)
 	tt1=eesubs(tt, [a], [(q^2-1)*a])
-	s2,e2=nesum(tt1, a, 1, q^2+sqrt2*q, congruence)
+	s2=nesum(tt1, a, 1, q^2+sqrt2*q, congruence)
 	tt1=eesubs(tt, [a], [(q^2+sqrt2*q+1)*a])
-	s3,e3=nesum(tt1, a, 1, q^2-2, congruence)
-	(1//8*s1-1//8*s2-1//8*s3, union(e1,e2,e3))
+	s3=nesum(tt1, a, 1, q^2-2, congruence)
+	1//8*s1-1//8*s2-1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
-	s2,e2=nesum(s1, b, 1, q^2+sqrt2*q, congruence)
-	(1//16*s2, union(e1,e2))
+	s1=nesum(tt, a, 1, q^2-sqrt2*q, congruence)
+	s2=nesum(s1, b, 1, q^2+sqrt2*q, congruence)
+	1//16*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, (q^2-sqrt2*q-4)*(q^2-sqrt2*q), congruence)
-	(1//96*s1, e1)
+	s1=nesum(tt, a, 1, (q^2-sqrt2*q-4)*(q^2-sqrt2*q), congruence)
+	1//96*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, (q^2+sqrt2*q-4)*(q^2+sqrt2*q), congruence)
-	(1//96*s1, e1)
+	s1=nesum(tt, a, 1, (q^2+sqrt2*q-4)*(q^2+sqrt2*q), congruence)
+	1//96*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2, congruence)
-	s2,e2=nesum(s1, b, 1, q^2, congruence)
+	s1=nesum(tt, a, 1, q^2, congruence)
+	s2=nesum(s1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [b])
-	s3,e3=nesum(tt1, b, 1, q^2, congruence)
+	s3=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [-b])
-	s4,e4=nesum(tt1, b, 1, q^2, congruence)
+	s4=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [(q*sqrt2-1)*b])
-	s5,e5=nesum(tt1, b, 1, q^2, congruence)
+	s5=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [-(q*sqrt2-1)*b])
-	s6,e6=nesum(tt1, b, 1, q^2, congruence)
+	s6=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [(q*sqrt2+1)*b])
-	s7,e7=nesum(tt1, b, 1, q^2, congruence)
+	s7=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [a], [-(q*sqrt2+1)*b])
-	s8,e8=nesum(tt1, b, 1, q^2, congruence)
+	s8=nesum(tt1, b, 1, q^2, congruence)
 	tt1=eesubs(tt, [b], [(q*sqrt2-1)*a])
-	s9,e9=nesum(tt1, a, 1, q^2, congruence)
+	s9=nesum(tt1, a, 1, q^2, congruence)
 	tt1=eesubs(tt, [b], [-(q*sqrt2-1)*a])
-	s10,e10=nesum(tt1, a, 1, q^2, congruence)
+	s10=nesum(tt1, a, 1, q^2, congruence)
 	tt1=eesubs(tt, [b], [(q*sqrt2+1)*a])
-	s11,e11=nesum(tt1, a, 1, q^2, congruence)
+	s11=nesum(tt1, a, 1, q^2, congruence)
 	tt1=eesubs(tt, [b], [-(q*sqrt2+1)*a])
-	s12,e12=nesum(tt1, a, 1, q^2, congruence)
+	s12=nesum(tt1, a, 1, q^2, congruence)
 	s13=eesubs(tt, [a,b], S.([b,(q^2+1)*1//3]))
 	s14=eesubs(tt, [a,b], S.([-b,(q^2+1)*1//3]))
 	s15=eesubs(tt, [a,b], S.([b,2*(q^2+1)*1//3]))
 	s16=eesubs(tt, [a,b], S.([-b,2*(q^2+1)*1//3]))
-	(1//48*s2-1//48*s3-1//48*s4-1//48*s5-1//48*s6-1//48*s7-1//48*s8-1//48*s9-1//48*s10-1//48*s11-1//48*s12+1//12*s13+1//12*s14+1//12*s15+1//12*s16, union(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12))
+	1//48*s2-1//48*s3-1//48*s4-1//48*s5-1//48*s6-1//48*s7-1//48*s8-1//48*s9-1//48*s10-1//48*s11-1//48*s12+1//12*s13+1//12*s14+1//12*s15+1//12*s16
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-q^2, congruence)
+	s1=nesum(tt, a, 1, q^4-q^2, congruence)
 	s2=eesubs(tt, [a], [(q^4-q^2+1)*1//3])
 	s3=eesubs(tt, [a], [2*(q^4-q^2+1)*1//3])
-	(1//6*s1-1//6*s2-1//6*s3, e1)
+	1//6*s1-1//6*s2-1//6*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-sqrt2*q^3+q^2-sqrt2*q, congruence)
-	(1//12*s1, e1)
+	s1=nesum(tt, a, 1, q^4-sqrt2*q^3+q^2-sqrt2*q, congruence)
+	1//12*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4+sqrt2*q^3+q^2+sqrt2*q, congruence)
-	(1//12*s1, e1)
+	s1=nesum(tt, a, 1, q^4+sqrt2*q^3+q^2+sqrt2*q, congruence)
+	1//12*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	s2,e2=nesum(s1, l, 1, q^2-2, congruence)
+	s1=nesum(tt, k, 1, q^2-2, congruence)
+	s2=nesum(s1, l, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [l], [k])
-	s3,e3=nesum(tt1, k, 1, q^2-2, congruence)
+	s3=nesum(tt1, k, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [l], [-k])
-	s4,e4=nesum(tt1, k, 1, q^2-2, congruence)
+	s4=nesum(tt1, k, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [k], [-(q*sqrt2-1)*l])
-	s5,e5=nesum(tt1, l, 1, q^2-2, congruence)
+	s5=nesum(tt1, l, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [k], [(q*sqrt2-1)*l])
-	s6,e6=nesum(tt1, l, 1, q^2-2, congruence)
+	s6=nesum(tt1, l, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [l], [-(q*sqrt2-1)*k])
-	s7,e7=nesum(tt1, k, 1, q^2-2, congruence)
+	s7=nesum(tt1, k, 1, q^2-2, congruence)
 	tt1=eesubs(tt, [l], [(q*sqrt2-1)*k])
-	s8,e8=nesum(tt1, k, 1, q^2-2, congruence)
-	(1//16*s2-1//16*s3-1//16*s4-1//16*s5-1//16*s6-1//16*s7-1//16*s8, union(e1,e2,e3,e4,e5,e6,e7,e8))
+	s8=nesum(tt1, k, 1, q^2-2, congruence)
+	1//16*s2-1//16*s3-1//16*s4-1//16*s5-1//16*s6-1//16*s7-1//16*s8
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2, congruence)
+	s1=nesum(tt, k, 1, q^2, congruence)
 	s2=eesubs(tt, [k], [(q^2+1)*1//3])
 	s3=eesubs(tt, [k], [2*(q^2+1)*1//3])
-	(1//2*s1-1//2*s2-1//2*s3, e1)
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2, congruence)
+	s1=nesum(tt, k, 1, q^2, congruence)
 	s2=eesubs(tt, [k], [(q^2+1)*1//3])
 	s3=eesubs(tt, [k], [2*(q^2+1)*1//3])
-	(1//2*s1-1//2*s2-1//2*s3, e1)
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-2, congruence)
+	s1=nesum(tt, k, 1, q^4-2, congruence)
 	tt1=eesubs(tt, [k], [(q^2-1)*k])
-	s2,e2=nesum(tt1, k, 1, q^2, congruence)
+	s2=nesum(tt1, k, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [(q^2+1)*k])
-	s3,e3=nesum(tt1, k, 1, q^2-2, congruence)
-	(1//4*s1-1//4*s2-1//4*s3, union(e1,e2,e3))
+	s3=nesum(tt1, k, 1, q^2-2, congruence)
+	1//4*s1-1//4*s2-1//4*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-sqrt2*q^3+sqrt2*q-2, congruence)
+	s1=nesum(tt, k, 1, q^4-sqrt2*q^3+sqrt2*q-2, congruence)
 	tt1=eesubs(tt, [k], [(q^2-1)*k])
-	s2,e2=nesum(tt1, k, 1, q^2-sqrt2*q, congruence)
+	s2=nesum(tt1, k, 1, q^2-sqrt2*q, congruence)
 	tt1=eesubs(tt, [k], [(q^2-sqrt2*q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q^2-2, congruence)
-	(1//8*s1-1//8*s2-1//8*s3, union(e1,e2,e3))
+	s3=nesum(tt1, k, 1, q^2-2, congruence)
+	1//8*s1-1//8*s2-1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4+sqrt2*q^3-sqrt2*q-2, congruence)
+	s1=nesum(tt, k, 1, q^4+sqrt2*q^3-sqrt2*q-2, congruence)
 	tt1=eesubs(tt, [k], [(q^2-1)*k])
-	s2,e2=nesum(tt1, k, 1, q^2+sqrt2*q, congruence)
+	s2=nesum(tt1, k, 1, q^2+sqrt2*q, congruence)
 	tt1=eesubs(tt, [k], [(q^2+sqrt2*q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q^2-2, congruence)
-	(1//8*s1-1//8*s2-1//8*s3, union(e1,e2,e3))
+	s3=nesum(tt1, k, 1, q^2-2, congruence)
+	1//8*s1-1//8*s2-1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-sqrt2*q, congruence)
-	s2,e2=nesum(s1, l, 1, q^2+sqrt2*q, congruence)
-	(1//16*s2, union(e1,e2))
+	s1=nesum(tt, k, 1, q^2-sqrt2*q, congruence)
+	s2=nesum(s1, l, 1, q^2+sqrt2*q, congruence)
+	1//16*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2, congruence)
-	s2,e2=nesum(s1, l, 1, q^2, congruence)
+	s1=nesum(tt, k, 1, q^2, congruence)
+	s2=nesum(s1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q^2, congruence)
+	s3=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s4,e4=nesum(tt1, l, 1, q^2, congruence)
+	s4=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [(q*sqrt2-1)*l])
-	s5,e5=nesum(tt1, l, 1, q^2, congruence)
+	s5=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [-(q*sqrt2-1)*l])
-	s6,e6=nesum(tt1, l, 1, q^2, congruence)
+	s6=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [(q*sqrt2+1)*l])
-	s7,e7=nesum(tt1, l, 1, q^2, congruence)
+	s7=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [k], [-(q*sqrt2+1)*l])
-	s8,e8=nesum(tt1, l, 1, q^2, congruence)
+	s8=nesum(tt1, l, 1, q^2, congruence)
 	tt1=eesubs(tt, [l], [(q*sqrt2-1)*k])
-	s9,e9=nesum(tt1, k, 1, q^2, congruence)
+	s9=nesum(tt1, k, 1, q^2, congruence)
 	tt1=eesubs(tt, [l], [-(q*sqrt2-1)*k])
-	s10,e10=nesum(tt1, k, 1, q^2, congruence)
+	s10=nesum(tt1, k, 1, q^2, congruence)
 	tt1=eesubs(tt, [l], [(q*sqrt2+1)*k])
-	s11,e11=nesum(tt1, k, 1, q^2, congruence)
+	s11=nesum(tt1, k, 1, q^2, congruence)
 	tt1=eesubs(tt, [l], [-(q*sqrt2+1)*k])
-	s12,e12=nesum(tt1, k, 1, q^2, congruence)
+	s12=nesum(tt1, k, 1, q^2, congruence)
 	s13=eesubs(tt, [k,l], S.([l,(q^2+1)*1//3]))
 	s14=eesubs(tt, [k,l], S.([-l,(q^2+1)*1//3]))
 	s15=eesubs(tt, [k,l], S.([l,2*(q^2+1)*1//3]))
 	s16=eesubs(tt, [k,l], S.([-l,2*(q^2+1)*1//3]))
-	(1//48*s2-1//48*s3-1//48*s4-1//48*s5-1//48*s6-1//48*s7-1//48*s8-1//48*s9-1//48*s10-1//48*s11-1//48*s12+1//12*s13+1//12*s14+1//12*s15+1//12*s16, union(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12))
+	1//48*s2-1//48*s3-1//48*s4-1//48*s5-1//48*s6-1//48*s7-1//48*s8-1//48*s9-1//48*s10-1//48*s11-1//48*s12+1//12*s13+1//12*s14+1//12*s15+1//12*s16
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-q^2, congruence)
+	s1=nesum(tt, k, 1, q^4-q^2, congruence)
 	s2=eesubs(tt, [k], [(q^4-q^2+1)*1//3])
 	s3=eesubs(tt, [k], [2*(q^4-q^2+1)*1//3])
-	(1//6*s1-1//6*s2-1//6*s3, e1)
+	1//6*s1-1//6*s2-1//6*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-sqrt2*q^3+q^2-sqrt2*q, congruence)
-	(1//12*s1, e1)
+	s1=nesum(tt, k, 1, q^4-sqrt2*q^3+q^2-sqrt2*q, congruence)
+	1//12*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4+sqrt2*q^3+q^2+sqrt2*q, congruence)
-	(1//12*s1, e1)
+	s1=nesum(tt, k, 1, q^4+sqrt2*q^3+q^2+sqrt2*q, congruence)
+	1//12*s1
 end
 ]
 

--- a/src/Tables/2G2/2G2.jl
+++ b/src/Tables/2G2/2G2.jl
@@ -268,110 +268,112 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i], [0])
 	s2=eesubs(tt, [i], [(q^2-1)*1//2])
-	s3,e1=nesum(tt, i, 0, q^2-2, congruence)
-	(1//2*s3-1//2*s2-1//2*s1, e1)
+	s3=nesum(tt, i, 0, q^2-2, congruence)
+	1//2*s3-1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-sqrt3*q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2-sqrt3*q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i], [(q^2+1)*1//4])
-	s2,e1=nesum(tt, i, 1, (q^2-1)*1//2, congruence)
+	s2=nesum(tt, i, 1, (q^2-1)*1//2, congruence)
 	s2=1//6*s2-1//6*s1
 	s1=eesubs(s2, [j], [0])
 	s2=eesubs(s2, [j], [1])
-	(s1+s2, e1)
+	s1+s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2+sqrt3*q, congruence)
-	(1//6*s1, e1)end
+	s1=nesum(tt, i, 1, q^2+sqrt3*q, congruence)
+	1//6*s1
+end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k], [0])
 	s2=eesubs(tt, [k], [(q^2-1)*1//2])
-	s3,e1=nesum(tt, k, 0, q^2-2, congruence)
-	(1//2*s3-1//2*s2-1//2*s1, e1)
+	s3=nesum(tt, k, 0, q^2-2, congruence)
+	1//2*s3-1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-sqrt3*q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2-sqrt3*q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k], [(q^2+1)*1//4])
-	s2,e1=nesum(tt, k, 1, (q^2-1)*1//2, congruence)
+	s2=nesum(tt, k, 1, (q^2-1)*1//2, congruence)
 	s2=1//6*s2-1//6*s1
 	s1=eesubs(s2, [l], [0])
 	s2=eesubs(s2, [l], [1])
-	(s1+s2, e1)
+	s1+s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+sqrt3*q, congruence)
-	(1//6*s1, e1)end
+	s1=nesum(tt, k, 1, q^2+sqrt3*q, congruence)
+	1//6*s1
+end
 ]
 
 classparams=[

--- a/src/Tables/3D4/3D4.0.jl
+++ b/src/Tables/3D4/3D4.0.jl
@@ -972,303 +972,303 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^3-2, congruence)
+	s1=nesum(tt, a, 1, q^3-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	s2,e2=nesum(tt1, a, 1, q^2+q, congruence)
-	(1//2*s1-1//2*s2, union(e1,e2))
+	s2=nesum(tt1, a, 1, q^2+q, congruence)
+	1//2*s1-1//2*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^3-2, congruence)
+	s1=nesum(tt, a, 1, q^3-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	s2,e2=nesum(tt1, a, 1, q^2+q, congruence)
-	(1//2*s1-1//2*s2, union(e1,e2))
+	s2=nesum(tt1, a, 1, q^2+q, congruence)
+	1//2*s1-1//2*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3-2, congruence)
-	s2,e2=nesum(s1, b, 0, q-2, congruence)
+	s1=nesum(tt, a, 0, q^3-2, congruence)
+	s2=nesum(s1, b, 0, q-2, congruence)
 	tt1=eesubs(tt, [b], [0])
-	s3,e3=nesum(tt1, a, 0, q^3-2, congruence)
+	s3=nesum(tt1, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q-1)*a,0]))
-	s4,e4=nesum(tt1, a, 0, q^2+q, congruence)
+	s4=nesum(tt1, a, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [a], [0])
-	s5,e5=nesum(tt1, b, 1, q-2, congruence)
-	(1//12*s2-1//4*s3+1//6*s4-1//4*s5, union(e1,e2,e3,e4,e5))
+	s5=nesum(tt1, b, 1, q-2, congruence)
+	1//12*s2-1//4*s3+1//6*s4-1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^4+q^3-q-2, congruence)
+	s1=nesum(tt, a, 0, q^4+q^3-q-2, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	s2,e2=nesum(tt1, a, 0, q^3-2, congruence)
+	s2=nesum(tt1, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a], [(q^3-1)*a])
-	s3,e3=nesum(tt1, a, 0, q, congruence)
+	s3=nesum(tt1, a, 0, q, congruence)
 	tt1=eesubs(tt, [a], [(q^3-1)*(q+1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*tt1, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3, congruence)
+	s1=nesum(tt, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	s2,e2=nesum(tt1, a, 0, q^2-q, congruence)
-	(1//2*s1-1//2*s2, union(e1,e2))
+	s2=nesum(tt1, a, 0, q^2-q, congruence)
+	1//2*s1-1//2*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3, congruence)
+	s1=nesum(tt, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	s2,e2=nesum(tt1, a, 0, q^2-q, congruence)
-	(1//2*s1-1//2*s2, union(e1,e2))
+	s2=nesum(tt1, a, 0, q^2-q, congruence)
+	1//2*s1-1//2*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^4-q^3+q-2, congruence)
+	s1=nesum(tt, a, 0, q^4-q^3+q-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	s2,e2=nesum(tt1, a, 0, q^3, congruence)
+	s2=nesum(tt1, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a], [(q^3+1)*a])
-	s3,e3=nesum(tt1, a, 0, q-2, congruence)
+	s3=nesum(tt1, a, 0, q-2, congruence)
 	tt1=eesubs(tt, [a], [(q^3+1)*(q-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*tt1, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^2+q, congruence)
-	s2,e2=nesum(s1, b, 0, q^2+q, congruence)
+	s1=nesum(tt, a, 0, q^2+q, congruence)
+	s2=nesum(s1, b, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s3,e3=nesum(tt1, a, 0, q^2+q, congruence)
+	s3=nesum(tt1, a, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [a,b], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^2-q, congruence)
-	s2,e2=nesum(s1, b, 0, q^2-q, congruence)
+	s1=nesum(tt, a, 0, q^2-q, congruence)
+	s2=nesum(s1, b, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s3,e3=nesum(tt1, a, 0, q^2-q, congruence)
+	s3=nesum(tt1, a, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [a,b], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-q^2, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^4-q^2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3, congruence)
-	s2,e2=nesum(s1, b, 1, q, congruence)
+	s1=nesum(tt, a, 0, q^3, congruence)
+	s2=nesum(s1, b, 1, q, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q^2-q+1)*a,2*a]))
-	s3,e3=nesum(tt1, a, 0, q, congruence)
+	s3=nesum(tt1, a, 0, q, congruence)
 	tt1=eesubs(tt, [a,b], S.([2*a,a]))
-	s4,e4=nesum(tt1, a, 0, q^3, congruence)
+	s4=nesum(tt1, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s5,e5=nesum(tt1, a, 0, q^3, congruence)
+	s5=nesum(tt1, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q+1)*a,0]))
-	s6,e6=nesum(tt1, a, 0, q^2-q, congruence)
+	s6=nesum(tt1, a, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q^3+1),0]))
-	(1//12*s2-1//4*s3-1//12*s4-1//12*s5+1//6*s6+1//4*tt1, union(e1,e2,e3,e4,e5,e6))
+	1//12*s2-1//4*s3-1//12*s4-1//12*s5+1//6*s6+1//4*tt1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^3-2, congruence)
+	s1=nesum(tt, k, 1, q^3-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q^2+q, congruence)
-	(1//2*s1-1//2*s2, union(e1,e2))
+	s2=nesum(tt1, k, 1, q^2+q, congruence)
+	1//2*s1-1//2*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^3-2, congruence)
+	s1=nesum(tt, k, 1, q^3-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q^2+q, congruence)
-	(1//2*s1-1//2*s2, union(e1,e2))
+	s2=nesum(tt1, k, 1, q^2+q, congruence)
+	1//2*s1-1//2*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3-2, congruence)
-	s2,e2=nesum(s1, l, 0, q-2, congruence)
+	s1=nesum(tt, k, 0, q^3-2, congruence)
+	s2=nesum(s1, l, 0, q-2, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 0, q^3-2, congruence)
+	s3=nesum(tt1, k, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [k,l], S.([(q-1)*k,0]))
-	s4,e4=nesum(tt1, k, 0, q^2+q, congruence)
+	s4=nesum(tt1, k, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [k], [0])
-	s5,e5=nesum(tt1, l, 1, q-2, congruence)
-	(1//12*s2-1//4*s3+1//6*s4-1//4*s5, union(e1,e2,e3,e4,e5))
+	s5=nesum(tt1, l, 1, q-2, congruence)
+	1//12*s2-1//4*s3+1//6*s4-1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4+q^3-q-2, congruence)
+	s1=nesum(tt, k, 1, q^4+q^3-q-2, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s2,e2=nesum(tt1, k, 1, q^3-2, congruence)
+	s2=nesum(tt1, k, 1, q^3-2, congruence)
 	tt1=eesubs(tt, [k], [(q^3-1)*k])
-	s3,e3=nesum(tt1, k, 1, q, congruence)
-	(1//4*s1-1//4*s2-1//4*s3, union(e1,e2,e3))
+	s3=nesum(tt1, k, 1, q, congruence)
+	1//4*s1-1//4*s2-1//4*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3, congruence)
+	s1=nesum(tt, k, 0, q^3, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s2,e2=nesum(tt1, k, 0, q^2-q, congruence)
-	(1//2*s1-1//2*s2, union(e1,e2))
+	s2=nesum(tt1, k, 0, q^2-q, congruence)
+	1//2*s1-1//2*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3, congruence)
+	s1=nesum(tt, k, 0, q^3, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s2,e2=nesum(tt1, k, 0, q^2-q, congruence)
-	(1//2*s1-1//2*s2, union(e1,e2))
+	s2=nesum(tt1, k, 0, q^2-q, congruence)
+	1//2*s1-1//2*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-q^3+q-2, congruence)
+	s1=nesum(tt, k, 1, q^4-q^3+q-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q^3, congruence)
+	s2=nesum(tt1, k, 1, q^3, congruence)
 	tt1=eesubs(tt, [k], [(q^3+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-2, congruence)
-	(1//4*s1-1//4*s2-1//4*s3, union(e1,e2,e3))
+	s3=nesum(tt1, k, 1, q-2, congruence)
+	1//4*s1-1//4*s2-1//4*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	s2,e2=nesum(s1, l, 1, q^2+q, congruence)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	s2=nesum(s1, l, 1, q^2+q, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 1, q^2+q, congruence)
-	(1//24*s2-1//12*s3, union(e1,e2,e3))
+	s3=nesum(tt1, k, 1, q^2+q, congruence)
+	1//24*s2-1//12*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^2-q, congruence)
-	s2,e2=nesum(s1, l, 0, q^2-q, congruence)
+	s1=nesum(tt, k, 0, q^2-q, congruence)
+	s2=nesum(s1, l, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 0, q^2-q, congruence)
+	s3=nesum(tt1, k, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [k,l], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-q^2, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, k, 1, q^4-q^2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^3, congruence)
-	s2,e2=nesum(s1, l, 1, q, congruence)
+	s1=nesum(tt, k, 1, q^3, congruence)
+	s2=nesum(s1, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 1, q^3, congruence)
+	s3=nesum(tt1, k, 1, q^3, congruence)
 	tt1=eesubs(tt, [k,l], S.([(q+1)*k,0]))
-	s4,e4=nesum(tt1, k, 1, q^2-q, congruence)
+	s4=nesum(tt1, k, 1, q^2-q, congruence)
 	tt1=eesubs(tt, [k], [0])
-	s5,e5=nesum(tt1, l, 1, q, congruence)
-	(1//12*s2-1//6*s3+1//6*s4-1//6*s5, union(e1,e2,e3,e4,e5))
+	s5=nesum(tt1, l, 1, q, congruence)
+	1//12*s2-1//6*s3+1//6*s4-1//6*s5
 end
 ]
 

--- a/src/Tables/3D4/3D4.11.jl
+++ b/src/Tables/3D4/3D4.11.jl
@@ -1236,357 +1236,357 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, (q-2), congruence)
+	s1=nesum(tt, a, 1, (q-2), congruence)
 	tt1=eesubs(tt, [a], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, (q-2), congruence)
+	s1=nesum(tt, a, 1, (q-2), congruence)
 	tt1=eesubs(tt, [a], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3-2, congruence)
+	s1=nesum(tt, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	s2,e2=nesum(tt1, a, 0, q^2+q, congruence)
+	s2=nesum(tt1, a, 0, q^2+q, congruence)
 	s3=eesubs(tt, [a], [(q^3-1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3-2, congruence)
+	s1=nesum(tt, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	s2,e2=nesum(tt1, a, 0, q^2+q, congruence)
+	s2=nesum(tt1, a, 0, q^2+q, congruence)
 	s3=eesubs(tt, [a], [(q^3-1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3-2, congruence)
-	s2,e2=nesum(s1, b, 1, q-2, congruence)
+	s1=nesum(tt, a, 0, q^3-2, congruence)
+	s2=nesum(s1, b, 1, q-2, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q^2+q+1)*a,2*a]))
-	s3,e3=nesum(tt1, a, 0, q-2, congruence)
+	s3=nesum(tt1, a, 0, q-2, congruence)
 	tt1=eesubs(tt, [a,b], S.([2*a,a]))
-	s4,e4=nesum(tt1, a, 0, q^3-2, congruence)
+	s4=nesum(tt1, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s5,e5=nesum(tt1, a, 0, q^3-2, congruence)
+	s5=nesum(tt1, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q-1)*a,0]))
-	s6,e6=nesum(tt1, a, 0, q^2+q, congruence)
+	s6=nesum(tt1, a, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q^3-1)*1//2,0]))
 	tt2=eesubs(tt, [a,b], S.([(q^3-1),0]))
-	(1//12*s2-1//4*s3-1//12*s4-1//12*s5+1//6*s6+1//4*tt1+1//4*tt2, union(e1,e2,e3,e4,e5,e6))
+	1//12*s2-1//4*s3-1//12*s4-1//12*s5+1//6*s6+1//4*tt1+1//4*tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q, congruence)
+	s1=nesum(tt, a, 1, q, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q, congruence)
+	s1=nesum(tt, a, 1, q, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^4+q^3-q-2, congruence)
+	s1=nesum(tt, a, 0, q^4+q^3-q-2, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	s2,e2=nesum(tt1, a, 0, q^3-2, congruence)
+	s2=nesum(tt1, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a], [(q^3-1)*a])
-	s3,e3=nesum(tt1, a, 0, q, congruence)
+	s3=nesum(tt1, a, 0, q, congruence)
 	tt1=eesubs(tt, [a], [(q^3-1)*(q+1)*1//2])
 	tt2=eesubs(tt, [a], [(q^3-1)*(q+1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3, congruence)
+	s1=nesum(tt, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	s2,e2=nesum(tt1, a, 0, q^2-q, congruence)
+	s2=nesum(tt1, a, 0, q^2-q, congruence)
 	s3=eesubs(tt, [a], [(q^3+1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3, congruence)
+	s1=nesum(tt, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	s2,e2=nesum(tt1, a, 0, q^2-q, congruence)
+	s2=nesum(tt1, a, 0, q^2-q, congruence)
 	s3=eesubs(tt, [a], [(q^3+1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^4-q^3+q-2, congruence)
+	s1=nesum(tt, a, 0, q^4-q^3+q-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	s2,e2=nesum(tt1, a, 0, q^3, congruence)
+	s2=nesum(tt1, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a], [(q^3+1)*a])
-	s3,e3=nesum(tt1, a, 0, q-2, congruence)
+	s3=nesum(tt1, a, 0, q-2, congruence)
 	tt1=eesubs(tt, [a], [(q^3+1)*(q-1)*1//2])
 	tt2=eesubs(tt, [a], [(q^3+1)*(q-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^2+q, congruence)
-	s2,e2=nesum(s1, b, 0, q^2+q, congruence)
+	s1=nesum(tt, a, 0, q^2+q, congruence)
+	s2=nesum(s1, b, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s3,e3=nesum(tt1, a, 0, q^2+q, congruence)
+	s3=nesum(tt1, a, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [a,b], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^2-q, congruence)
-	s2,e2=nesum(s1, b, 0, q^2-q, congruence)
+	s1=nesum(tt, a, 0, q^2-q, congruence)
+	s2=nesum(s1, b, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s3,e3=nesum(tt1, a, 0, q^2-q, congruence)
+	s3=nesum(tt1, a, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [a,b], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-q^2, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^4-q^2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3, congruence)
-	s2,e2=nesum(s1, b, 1, q, congruence)
+	s1=nesum(tt, a, 0, q^3, congruence)
+	s2=nesum(s1, b, 1, q, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q^2-q+1)*a,2*a]))
-	s3,e3=nesum(tt1, a, 0, q, congruence)
+	s3=nesum(tt1, a, 0, q, congruence)
 	tt1=eesubs(tt, [a,b], S.([2*a,a]))
-	s4,e4=nesum(tt1, a, 0, q^3, congruence)
+	s4=nesum(tt1, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s5,e5=nesum(tt1, a, 0, q^3, congruence)
+	s5=nesum(tt1, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q+1)*a,0]))
-	s6,e6=nesum(tt1, a, 0, q^2-q, congruence)
+	s6=nesum(tt1, a, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q^3+1)*1//2,0]))
 	tt2=eesubs(tt, [a,b], S.([(q^3+1),0]))
-	(1//12*s2-1//4*s3-1//12*s4-1//12*s5+1//6*s6+1//4*tt1+1//4*tt2, union(e1,e2,e3,e4,e5,e6))
+	1//12*s2-1//4*s3-1//12*s4-1//12*s5+1//6*s6+1//4*tt1+1//4*tt2
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3-2, congruence)
+	s1=nesum(tt, k, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 0, q^2+q, congruence)
+	s2=nesum(tt1, k, 0, q^2+q, congruence)
 	s3=eesubs(tt, [k], [(q^3-1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3-2, congruence)
+	s1=nesum(tt, k, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 0, q^2+q, congruence)
+	s2=nesum(tt1, k, 0, q^2+q, congruence)
 	s3=eesubs(tt, [k], [(q^3-1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3-2, congruence)
-	s2,e2=nesum(s1, l, 0, q-2, congruence)
+	s1=nesum(tt, k, 0, q^3-2, congruence)
+	s2=nesum(s1, l, 0, q-2, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 0, q^3-2, congruence)
+	s3=nesum(tt1, k, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [k,l], S.([(q-1)*k,0]))
-	s4,e4=nesum(tt1, k, 0, q^2+q, congruence)
+	s4=nesum(tt1, k, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [k], [0])
-	s5,e5=nesum(tt1, l, 1, q-2, congruence)
+	s5=nesum(tt1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [k,l], S.([(q^3-1)*1//2,0]))
-	(1//12*s2-1//4*s3+1//6*s4-1//4*s5+1//4*tt1, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//4*s3+1//6*s4-1//4*s5+1//4*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^4+q^3-q-2, congruence)
+	s1=nesum(tt, k, 0, q^4+q^3-q-2, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s2,e2=nesum(tt1, k, 0, q^3-2, congruence)
+	s2=nesum(tt1, k, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [k], [(q^3-1)*k])
-	s3,e3=nesum(tt1, k, 0, q, congruence)
+	s3=nesum(tt1, k, 0, q, congruence)
 	tt1=eesubs(tt, [k], [(q^3-1)*(q+1)*1//2])
 	tt2=eesubs(tt, [k], [(q^3-1)*(q+1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3, congruence)
+	s1=nesum(tt, k, 0, q^3, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s2,e2=nesum(tt1, k, 0, q^2-q, congruence)
+	s2=nesum(tt1, k, 0, q^2-q, congruence)
 	s3=eesubs(tt, [k], [(q^3+1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3, congruence)
+	s1=nesum(tt, k, 0, q^3, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s2,e2=nesum(tt1, k, 0, q^2-q, congruence)
+	s2=nesum(tt1, k, 0, q^2-q, congruence)
 	s3=eesubs(tt, [k], [(q^3+1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^4-q^3+q-2, congruence)
+	s1=nesum(tt, k, 0, q^4-q^3+q-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 0, q^3, congruence)
+	s2=nesum(tt1, k, 0, q^3, congruence)
 	tt1=eesubs(tt, [k], [(q^3+1)*k])
-	s3,e3=nesum(tt1, k, 0, q-2, congruence)
+	s3=nesum(tt1, k, 0, q-2, congruence)
 	tt1=eesubs(tt, [k], [(q^3+1)*(q-1)*1//2])
 	tt2=eesubs(tt, [k], [(q^3+1)*(q-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^2+q, congruence)
-	s2,e2=nesum(s1, l, 0, q^2+q, congruence)
+	s1=nesum(tt, k, 0, q^2+q, congruence)
+	s2=nesum(s1, l, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 0, q^2+q, congruence)
+	s3=nesum(tt1, k, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [k,l], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^2-q, congruence)
-	s2,e2=nesum(s1, l, 0, q^2-q, congruence)
+	s1=nesum(tt, k, 0, q^2-q, congruence)
+	s2=nesum(s1, l, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 0, q^2-q, congruence)
+	s3=nesum(tt1, k, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [k,l], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-q^2, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, k, 1, q^4-q^2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^3, congruence)
-	s2,e2=nesum(s1, l, 1, q, congruence)
+	s1=nesum(tt, k, 1, q^3, congruence)
+	s2=nesum(s1, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 1, q^3, congruence)
+	s3=nesum(tt1, k, 1, q^3, congruence)
 	tt1=eesubs(tt, [k,l], S.([(q+1)*k,0]))
-	s4,e4=nesum(tt1, k, 1, q^2-q, congruence)
+	s4=nesum(tt1, k, 1, q^2-q, congruence)
 	tt1=eesubs(tt, [k], [0])
-	s5,e5=nesum(tt1, l, 1, q, congruence)
+	s5=nesum(tt1, l, 1, q, congruence)
 	tt1=eesubs(tt, [k,l], S.([(q^3+1)*1//2,0]))
-	(1//12*s2-1//6*s3+1//6*s4-1//6*s5+1//4*tt1, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//6*s3+1//6*s4-1//6*s5+1//4*tt1
 end
 ]
 

--- a/src/Tables/3D4/3D4.13.jl
+++ b/src/Tables/3D4/3D4.13.jl
@@ -1236,357 +1236,357 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, (q-2), congruence)
+	s1=nesum(tt, a, 1, (q-2), congruence)
 	tt1=eesubs(tt, [a], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, (q-2), congruence)
+	s1=nesum(tt, a, 1, (q-2), congruence)
 	tt1=eesubs(tt, [a], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3-2, congruence)
+	s1=nesum(tt, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	s2,e2=nesum(tt1, a, 0, q^2+q, congruence)
+	s2=nesum(tt1, a, 0, q^2+q, congruence)
 	s3=eesubs(tt, [a], [(q^3-1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3-2, congruence)
+	s1=nesum(tt, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	s2,e2=nesum(tt1, a, 0, q^2+q, congruence)
+	s2=nesum(tt1, a, 0, q^2+q, congruence)
 	s3=eesubs(tt, [a], [(q^3-1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3-2, congruence)
-	s2,e2=nesum(s1, b, 1, q-2, congruence)
+	s1=nesum(tt, a, 0, q^3-2, congruence)
+	s2=nesum(s1, b, 1, q-2, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q^2+q+1)*a,2*a]))
-	s3,e3=nesum(tt1, a, 0, q-2, congruence)
+	s3=nesum(tt1, a, 0, q-2, congruence)
 	tt1=eesubs(tt, [a,b], S.([2*a,a]))
-	s4,e4=nesum(tt1, a, 0, q^3-2, congruence)
+	s4=nesum(tt1, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s5,e5=nesum(tt1, a, 0, q^3-2, congruence)
+	s5=nesum(tt1, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q-1)*a,0]))
-	s6,e6=nesum(tt1, a, 0, q^2+q, congruence)
+	s6=nesum(tt1, a, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q^3-1)*1//2,0]))
 	tt2=eesubs(tt, [a,b], S.([(q^3-1),0]))
-	(1//12*s2-1//4*s3-1//12*s4-1//12*s5+1//6*s6+1//4*tt1+1//4*tt2, union(e1,e2,e3,e4,e5,e6))
+	1//12*s2-1//4*s3-1//12*s4-1//12*s5+1//6*s6+1//4*tt1+1//4*tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q, congruence)
+	s1=nesum(tt, a, 1, q, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q, congruence)
+	s1=nesum(tt, a, 1, q, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^4+q^3-q-2, congruence)
+	s1=nesum(tt, a, 0, q^4+q^3-q-2, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	s2,e2=nesum(tt1, a, 0, q^3-2, congruence)
+	s2=nesum(tt1, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a], [(q^3-1)*a])
-	s3,e3=nesum(tt1, a, 0, q, congruence)
+	s3=nesum(tt1, a, 0, q, congruence)
 	tt1=eesubs(tt, [a], [(q^3-1)*(q+1)*1//2])
 	tt2=eesubs(tt, [a], [(q^3-1)*(q+1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3, congruence)
+	s1=nesum(tt, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	s2,e2=nesum(tt1, a, 0, q^2-q, congruence)
+	s2=nesum(tt1, a, 0, q^2-q, congruence)
 	s3=eesubs(tt, [a], [(q^3+1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3, congruence)
+	s1=nesum(tt, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	s2,e2=nesum(tt1, a, 0, q^2-q, congruence)
+	s2=nesum(tt1, a, 0, q^2-q, congruence)
 	s3=eesubs(tt, [a], [(q^3+1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^4-q^3+q-2, congruence)
+	s1=nesum(tt, a, 0, q^4-q^3+q-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*a])
-	s2,e2=nesum(tt1, a, 0, q^3, congruence)
+	s2=nesum(tt1, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a], [(q^3+1)*a])
-	s3,e3=nesum(tt1, a, 0, q-2, congruence)
+	s3=nesum(tt1, a, 0, q-2, congruence)
 	tt1=eesubs(tt, [a], [(q^3+1)*(q-1)*1//2])
 	tt2=eesubs(tt, [a], [(q^3+1)*(q-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^2+q, congruence)
-	s2,e2=nesum(s1, b, 0, q^2+q, congruence)
+	s1=nesum(tt, a, 0, q^2+q, congruence)
+	s2=nesum(s1, b, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s3,e3=nesum(tt1, a, 0, q^2+q, congruence)
+	s3=nesum(tt1, a, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [a,b], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^2-q, congruence)
-	s2,e2=nesum(s1, b, 0, q^2-q, congruence)
+	s1=nesum(tt, a, 0, q^2-q, congruence)
+	s2=nesum(s1, b, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s3,e3=nesum(tt1, a, 0, q^2-q, congruence)
+	s3=nesum(tt1, a, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [a,b], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q^4-q^2, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, a, 1, q^4-q^2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 0, q^3, congruence)
-	s2,e2=nesum(s1, b, 1, q, congruence)
+	s1=nesum(tt, a, 0, q^3, congruence)
+	s2=nesum(s1, b, 1, q, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q^2-q+1)*a,2*a]))
-	s3,e3=nesum(tt1, a, 0, q, congruence)
+	s3=nesum(tt1, a, 0, q, congruence)
 	tt1=eesubs(tt, [a,b], S.([2*a,a]))
-	s4,e4=nesum(tt1, a, 0, q^3, congruence)
+	s4=nesum(tt1, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [b], [a])
-	s5,e5=nesum(tt1, a, 0, q^3, congruence)
+	s5=nesum(tt1, a, 0, q^3, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q+1)*a,0]))
-	s6,e6=nesum(tt1, a, 0, q^2-q, congruence)
+	s6=nesum(tt1, a, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [a,b], S.([(q^3+1)*1//2,0]))
 	tt2=eesubs(tt, [a,b], S.([(q^3+1),0]))
-	(1//12*s2-1//4*s3-1//12*s4-1//12*s5+1//6*s6+1//4*tt1+1//4*tt2, union(e1,e2,e3,e4,e5,e6))
+	1//12*s2-1//4*s3-1//12*s4-1//12*s5+1//6*s6+1//4*tt1+1//4*tt2
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3-2, congruence)
+	s1=nesum(tt, k, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 0, q^2+q, congruence)
+	s2=nesum(tt1, k, 0, q^2+q, congruence)
 	s3=eesubs(tt, [k], [(q^3-1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3-2, congruence)
+	s1=nesum(tt, k, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 0, q^2+q, congruence)
+	s2=nesum(tt1, k, 0, q^2+q, congruence)
 	s3=eesubs(tt, [k], [(q^3-1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3-2, congruence)
-	s2,e2=nesum(s1, l, 0, q-2, congruence)
+	s1=nesum(tt, k, 0, q^3-2, congruence)
+	s2=nesum(s1, l, 0, q-2, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 0, q^3-2, congruence)
+	s3=nesum(tt1, k, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [k,l], S.([(q-1)*k,0]))
-	s4,e4=nesum(tt1, k, 0, q^2+q, congruence)
+	s4=nesum(tt1, k, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [k], [0])
-	s5,e5=nesum(tt1, l, 1, q-2, congruence)
+	s5=nesum(tt1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [k,l], S.([(q^3-1)*1//2,0]))
-	(1//12*s2-1//4*s3+1//6*s4-1//4*s5+1//4*tt1, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//4*s3+1//6*s4-1//4*s5+1//4*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^4+q^3-q-2, congruence)
+	s1=nesum(tt, k, 0, q^4+q^3-q-2, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s2,e2=nesum(tt1, k, 0, q^3-2, congruence)
+	s2=nesum(tt1, k, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [k], [(q^3-1)*k])
-	s3,e3=nesum(tt1, k, 0, q, congruence)
+	s3=nesum(tt1, k, 0, q, congruence)
 	tt1=eesubs(tt, [k], [(q^3-1)*(q+1)*1//2])
 	tt2=eesubs(tt, [k], [(q^3-1)*(q+1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3, congruence)
+	s1=nesum(tt, k, 0, q^3, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s2,e2=nesum(tt1, k, 0, q^2-q, congruence)
+	s2=nesum(tt1, k, 0, q^2-q, congruence)
 	s3=eesubs(tt, [k], [(q^3+1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^3, congruence)
+	s1=nesum(tt, k, 0, q^3, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s2,e2=nesum(tt1, k, 0, q^2-q, congruence)
+	s2=nesum(tt1, k, 0, q^2-q, congruence)
 	s3=eesubs(tt, [k], [(q^3+1)*1//2])
-	(1//2*s1-1//2*s2-1//2*s3, union(e1,e2))
+	1//2*s1-1//2*s2-1//2*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^4-q^3+q-2, congruence)
+	s1=nesum(tt, k, 0, q^4-q^3+q-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 0, q^3, congruence)
+	s2=nesum(tt1, k, 0, q^3, congruence)
 	tt1=eesubs(tt, [k], [(q^3+1)*k])
-	s3,e3=nesum(tt1, k, 0, q-2, congruence)
+	s3=nesum(tt1, k, 0, q-2, congruence)
 	tt1=eesubs(tt, [k], [(q^3+1)*(q-1)*1//2])
 	tt2=eesubs(tt, [k], [(q^3+1)*(q-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*tt1+1//4*tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^2+q, congruence)
-	s2,e2=nesum(s1, l, 0, q^2+q, congruence)
+	s1=nesum(tt, k, 0, q^2+q, congruence)
+	s2=nesum(s1, l, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 0, q^2+q, congruence)
+	s3=nesum(tt1, k, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [k,l], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 0, q^2-q, congruence)
-	s2,e2=nesum(s1, l, 0, q^2-q, congruence)
+	s1=nesum(tt, k, 0, q^2-q, congruence)
+	s2=nesum(s1, l, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 0, q^2-q, congruence)
+	s3=nesum(tt1, k, 0, q^2-q, congruence)
 	tt1=eesubs(tt, [k,l], S.([0,0]))
-	(1//24*s2-1//6*s3+1//8*tt1, union(e1,e2,e3))
+	1//24*s2-1//6*s3+1//8*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^4-q^2, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, k, 1, q^4-q^2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^3, congruence)
-	s2,e2=nesum(s1, l, 1, q, congruence)
+	s1=nesum(tt, k, 1, q^3, congruence)
+	s2=nesum(s1, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [0])
-	s3,e3=nesum(tt1, k, 1, q^3, congruence)
+	s3=nesum(tt1, k, 1, q^3, congruence)
 	tt1=eesubs(tt, [k,l], S.([(q+1)*k,0]))
-	s4,e4=nesum(tt1, k, 1, q^2-q, congruence)
+	s4=nesum(tt1, k, 1, q^2-q, congruence)
 	tt1=eesubs(tt, [k], [0])
-	s5,e5=nesum(tt1, l, 1, q, congruence)
+	s5=nesum(tt1, l, 1, q, congruence)
 	tt1=eesubs(tt, [k,l], S.([(q^3+1)*1//2,0]))
-	(1//12*s2-1//6*s3+1//6*s4-1//6*s5+1//4*tt1, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//6*s3+1//6*s4-1//6*s5+1//4*tt1
 end
 ]
 

--- a/src/Tables/A1/GL2.jl
+++ b/src/Tables/A1/GL2.jl
@@ -38,16 +38,16 @@ function (tt::Cyclotomic)
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [j], [i])
-	s2,e1=nesum(tt, j, 0, q-2, congruence)
+	s2=nesum(tt, j, 0, q-2, congruence)
 	s1=s2-s1
-	s2,e2=nesum(s1, i, 0, q-2, congruence)
-	(1//2*s2, union(e1,e2))
+	s2=nesum(s1, i, 0, q-2, congruence)
+	1//2*s2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i], [(q+1)*i])
-	s1,e1=nesum(s1, i, 0, q-2, congruence)
-	s2,e2=nesum(tt, i, 0, q^2-2, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s1=nesum(s1, i, 0, q-2, congruence)
+	s2=nesum(tt, i, 0, q^2-2, congruence)
+	1//2*s2-1//2*s1
 end
 ]
 
@@ -60,16 +60,16 @@ function (tt::Cyclotomic)
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [l], [k])
-	s2,e1=nesum(tt, l, 0, q-2, congruence)
+	s2=nesum(tt, l, 0, q-2, congruence)
 	s1=s2-s1
-	s2,e2=nesum(s1, k, 0, q-2, congruence)
-	(1//2*s2, union(e1,e2))
+	s2=nesum(s1, k, 0, q-2, congruence)
+	1//2*s2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k], [(q+1)*k])
-	s1,e1=nesum(s1, k, 0, q-2, congruence)
-	s2,e2=nesum(tt, k, 0, q^2-2, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s1=nesum(s1, k, 0, q-2, congruence)
+	s2=nesum(tt, k, 0, q^2-2, congruence)
+	1//2*s2-1//2*s1
 end
 ]
 

--- a/src/Tables/A1/GU2.jl
+++ b/src/Tables/A1/GU2.jl
@@ -38,16 +38,16 @@ function (tt::Cyclotomic)
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [l], [k])
-	s2,e1=nesum(tt, l, 0, q, congruence)
+	s2=nesum(tt, l, 0, q, congruence)
 	s1=s2-s1
-	s2,e2=nesum(s1, k, 0, q, congruence)
-	(1//2*s2, union(e1,e2))
+	s2=nesum(s1, k, 0, q, congruence)
+	1//2*s2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k], [(q-1)*k])
-	s1,e1=nesum(s1, k, 0, q, congruence)
-	s2,e2=nesum(tt, k, 0, q^2-2, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s1=nesum(s1, k, 0, q, congruence)
+	s2=nesum(tt, k, 0, q^2-2, congruence)
+	1//2*s2-1//2*s1
 end
 ]
 
@@ -60,16 +60,16 @@ function (tt::Cyclotomic)
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [v], [u])
-	s2,e1=nesum(tt, v, 0, q, congruence)
+	s2=nesum(tt, v, 0, q, congruence)
 	s1=s2-s1
-	s2,e2=nesum(s1, u, 0, q, congruence)
-	(1//2*s2, union(e1,e2))
+	s2=nesum(s1, u, 0, q, congruence)
+	1//2*s2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [u], [(q-1)*u])
-	s1,e1=nesum(s1, u, 0, q, congruence)
-	s2,e2=nesum(tt, u, 0, q^2-2, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s1=nesum(s1, u, 0, q, congruence)
+	s2=nesum(tt, u, 0, q^2-2, congruence)
+	1//2*s2-1//2*s1
 end
 ]
 

--- a/src/Tables/A1/PGL2.1.jl
+++ b/src/Tables/A1/PGL2.1.jl
@@ -45,26 +45,26 @@ chardegree = R.([1, q, q+1, q-1])
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
+	s1=nesum(tt, i, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end
 ]
 
@@ -76,14 +76,14 @@ function (tt::Cyclotomic)
 	nesum(tt, k, 0, 1, congruence)
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
+	s1=nesum(tt, k, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end
 ]
 

--- a/src/Tables/A1/PSL2.1.jl
+++ b/src/Tables/A1/PSL2.1.jl
@@ -63,49 +63,49 @@ chardegree = R.([1, q^2, 1//2*(q^2+1), 1//2*(q^2+1), q^2+1, q^2-1])
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q^2-3)*1//2, congruence)
+	s1=nesum(tt, i, 1, (q^2-3)*1//2, congruence)
 	s2=eesubs(tt, [i], [(q^2-1)*1//4])
-	(1//2*s1-1//2*s2, e1)
+	1//2*s1-1//2*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q^2-1)*1//2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, (q^2-1)*1//2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k], [(q^2-1)*1//4])
-	t1,e1=nesum(tt, k, 1, (q^2-3)*1//2, congruence)
-	(1//2*t1-1//2*s1, e1)
+	t1=nesum(tt, k, 1, (q^2-3)*1//2, congruence)
+	1//2*t1-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q^2-1)*1//2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, (q^2-1)*1//2, congruence)
+	1//2*s1
 end
 ]
 

--- a/src/Tables/A1/PSL2.3.jl
+++ b/src/Tables/A1/PSL2.3.jl
@@ -63,49 +63,49 @@ chardegree = R.([1, q^2, 1//2*(q^2-1), 1//2*(q^2-1), q^2+1, q^2-1])
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q^2-3)*1//2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, (q^2-3)*1//2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q^2-1)*1//2, congruence)
+	s1=nesum(tt, i, 1, (q^2-1)*1//2, congruence)
 	s2=eesubs(tt, [i], [(q^2+1)*1//4])
-	(1//2*s1-1//2*s2, e1)
+	1//2*s1-1//2*s2
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q^2-3)*1//2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, (q^2-3)*1//2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k], [(q^2+1)*1//4])
-	t1,e1=nesum(tt, k, 1, (q^2-1)*1//2, congruence)
-	(1//2*t1-1//2*s1, e1)
+	t1=nesum(tt, k, 1, (q^2-1)*1//2, congruence)
+	1//2*t1-1//2*s1
 end
 ]
 

--- a/src/Tables/A1/SL2.0.jl
+++ b/src/Tables/A1/SL2.0.jl
@@ -31,35 +31,35 @@ chardegree = R.([1, q, q+1, q-1])
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, a, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, a, 1, q, congruence)
+	1//2*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, n, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, n, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, n, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, n, 1, q, congruence)
+	1//2*s1
 end
 ]
 

--- a/src/Tables/A1/SL2.1.jl
+++ b/src/Tables/A1/SL2.1.jl
@@ -84,44 +84,44 @@ function (tt::Cyclotomic)
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i], [(q^2-1)*1//2])
-	t1,e1=nesum(tt, i, 1, q^2-2, congruence)
-	(1//2*t1-1//2*s1, e1)
+	t1=nesum(tt, i, 1, q^2-2, congruence)
+	1//2*t1-1//2*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i], [(q^2+1)*1//2])
-	t1,e1=nesum(tt, i, 1, q^2, congruence)
-	(1//2*t1-1//2*s1, e1)
+	t1=nesum(tt, i, 1, q^2, congruence)
+	1//2*t1-1//2*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k], [(q^2-1)*1//2])
-	t1,e1=nesum(tt, k, 1, q^2-2, congruence)
-	(1//2*t1-1//2*s1, e1)
+	t1=nesum(tt, k, 1, q^2-2, congruence)
+	1//2*t1-1//2*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k], [(q^2+1)*1//2])
-	t1,e1=nesum(tt, k, 1, q^2, congruence)
-	(1//2*t1-1//2*s1, e1)
+	t1=nesum(tt, k, 1, q^2, congruence)
+	1//2*t1-1//2*s1
 end
 ]
 

--- a/src/Tables/A2/GL3.jl
+++ b/src/Tables/A2/GL3.jl
@@ -113,49 +113,49 @@ function (tt::Cyclotomic)
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [b], [a])
-	ss4,e1=nesum(tt, b, 0, q-2, congruence)
+	ss4=nesum(tt, b, 0, q-2, congruence)
 	ss5=ss4-tt1
-	ss5,e2=nesum(ss5, a, 0, q-2, congruence)
-	(ss5, union(e1,e2))
+	ss5=nesum(ss5, a, 0, q-2, congruence)
+	ss5
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [b], [a])
-	ss4,e1=nesum(tt, b, 0, q-2, congruence)
+	ss4=nesum(tt, b, 0, q-2, congruence)
 	ss5=ss4-tt1
-	ss5,e2=nesum(ss5, a, 0, q-2, congruence)
-	(ss5, union(e1,e2))
+	ss5=nesum(ss5, a, 0, q-2, congruence)
+	ss5
 end,
 function (tt::Cyclotomic)
-	ss6a,e1=nesum(tt, a, 0, q-2, congruence)
-	ss6b,e2=nesum(ss6a, b, 0, q-2, congruence)
-	ss6,e3=nesum(ss6b, c, 0, q-2, congruence)
+	ss6a=nesum(tt, a, 0, q-2, congruence)
+	ss6b=nesum(ss6a, b, 0, q-2, congruence)
+	ss6=nesum(ss6b, c, 0, q-2, congruence)
 	tt1=eesubs(tt, [b], [a])
-	ss7a,e4=nesum(tt1, a, 0, q-2, congruence)
-	ss7,e5=nesum(ss7a, c, 0, q-2, congruence)
+	ss7a=nesum(tt1, a, 0, q-2, congruence)
+	ss7=nesum(ss7a, c, 0, q-2, congruence)
 	tt2=eesubs(tt, [c], [b])
-	ss8a,e6=nesum(tt2, a, 0, q-2, congruence)
-	ss8,e7=nesum(ss8a, b, 0, q-2, congruence)
+	ss8a=nesum(tt2, a, 0, q-2, congruence)
+	ss8=nesum(ss8a, b, 0, q-2, congruence)
 	tt3=eesubs(tt, [c], [a])
-	ss9a,e8=nesum(tt3, a, 0, q-2, congruence)
-	ss9,e9=nesum(ss9a, b, 0, q-2, congruence)
+	ss9a=nesum(tt3, a, 0, q-2, congruence)
+	ss9=nesum(ss9a, b, 0, q-2, congruence)
 	tt4a=eesubs(tt, [b], [a])
 	tt4=eesubs(tt4a, [c], [a])
-	ss10,e10=nesum(tt4, a, 0, q-2, congruence)
-	(1//6*ss6-1//6*ss7-1//6*ss8-1//6*ss9+1//3*ss10, union(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10))
+	ss10=nesum(tt4, a, 0, q-2, congruence)
+	1//6*ss6-1//6*ss7-1//6*ss8-1//6*ss9+1//3*ss10
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, b, 0, q^2-2, congruence)
+	ss7=nesum(tt, b, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [b], [(q+1)*b])
-	ss8,e2=nesum(tt1, b, 0, q-2, congruence)
+	ss8=nesum(tt1, b, 0, q-2, congruence)
 	tt1=ss7-ss8
-	ss9,e3=nesum(tt1, a, 0, q-2, congruence)
-	(1//2*ss9, union(e1,e2,e3))
+	ss9=nesum(tt1, a, 0, q-2, congruence)
+	1//2*ss9
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, a, 0, q^3-2, congruence)
+	ss8=nesum(tt, a, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [a], [(q^2+q+1)*a])
-	ss9,e2=nesum(tt1, a, 0, q-2, congruence)
-	(1//3*ss8-1//3*ss9, union(e1,e2))
+	ss9=nesum(tt1, a, 0, q-2, congruence)
+	1//3*ss8-1//3*ss9
 end
 ]
 
@@ -171,49 +171,49 @@ function (tt::Cyclotomic)
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [m], [n])
-	ss4,e1=nesum(tt, m, 0, q-2, congruence)
+	ss4=nesum(tt, m, 0, q-2, congruence)
 	ss5=ss4-tt1
-	ss5,e2=nesum(ss5, n, 0, q-2, congruence)
-	(ss5, union(e1,e2))
+	ss5=nesum(ss5, n, 0, q-2, congruence)
+	ss5
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [m], [n])
-	ss4,e1=nesum(tt, m, 0, q-2, congruence)
+	ss4=nesum(tt, m, 0, q-2, congruence)
 	ss5=ss4-tt1
-	ss5,e2=nesum(ss5, n, 0, q-2, congruence)
-	(ss5, union(e1,e2))
+	ss5=nesum(ss5, n, 0, q-2, congruence)
+	ss5
 end,
 function (tt::Cyclotomic)
-	ss6a,e1=nesum(tt, n, 0, q-2, congruence)
-	ss6b,e2=nesum(ss6a, m, 0, q-2, congruence)
-	ss6,e3=nesum(ss6b, l, 0, q-2, congruence)
+	ss6a=nesum(tt, n, 0, q-2, congruence)
+	ss6b=nesum(ss6a, m, 0, q-2, congruence)
+	ss6=nesum(ss6b, l, 0, q-2, congruence)
 	tt1=eesubs(tt, [m], [n])
-	ss7a,e4=nesum(tt1, n, 0, q-2, congruence)
-	ss7,e5=nesum(ss7a, l, 0, q-2, congruence)
+	ss7a=nesum(tt1, n, 0, q-2, congruence)
+	ss7=nesum(ss7a, l, 0, q-2, congruence)
 	tt2=eesubs(tt, [l], [m])
-	ss8a,e6=nesum(tt2, n, 0, q-2, congruence)
-	ss8,e7=nesum(ss8a, m, 0, q-2, congruence)
+	ss8a=nesum(tt2, n, 0, q-2, congruence)
+	ss8=nesum(ss8a, m, 0, q-2, congruence)
 	tt3=eesubs(tt, [l], [n])
-	ss9a,e8=nesum(tt3, n, 0, q-2, congruence)
-	ss9,e9=nesum(ss9a, m, 0, q-2, congruence)
+	ss9a=nesum(tt3, n, 0, q-2, congruence)
+	ss9=nesum(ss9a, m, 0, q-2, congruence)
 	tt4a=eesubs(tt, [m], [n])
 	tt4=eesubs(tt4a, [l], [n])
-	ss10,e10=nesum(tt4, n, 0, q-2, congruence)
-	(1//6*ss6-1//6*ss7-1//6*ss8-1//6*ss9+1//3*ss10, union(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10))
+	ss10=nesum(tt4, n, 0, q-2, congruence)
+	1//6*ss6-1//6*ss7-1//6*ss8-1//6*ss9+1//3*ss10
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, n, 0, q^2-2, congruence)
+	ss7=nesum(tt, n, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [n], [(q+1)*n])
-	ss8,e2=nesum(tt1, n, 0, q-2, congruence)
+	ss8=nesum(tt1, n, 0, q-2, congruence)
 	tt1=ss7-ss8
-	ss9,e3=nesum(tt1, m, 0, q-2, congruence)
-	(1//2*ss9, union(e1,e2,e3))
+	ss9=nesum(tt1, m, 0, q-2, congruence)
+	1//2*ss9
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, n, 0, q^3-2, congruence)
+	ss8=nesum(tt, n, 0, q^3-2, congruence)
 	tt1=eesubs(tt, [n], [(q^2+q+1)*n])
-	ss9,e2=nesum(tt1, n, 0, q-2, congruence)
-	(1//3*ss8-1//3*ss9, union(e1,e2))
+	ss9=nesum(tt1, n, 0, q-2, congruence)
+	1//3*ss8-1//3*ss9
 end
 ]
 

--- a/src/Tables/A2/PGL3.1.jl
+++ b/src/Tables/A2/PGL3.1.jl
@@ -123,45 +123,45 @@ chardegree = R.([1, q^2+q, q^3, q^2+q+1, q*(q^2+q+1), (q+1)*(q^2+q+1), (q-1)*(q^
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
-end,
-function (tt::Cyclotomic)
-	nesum(tt, a, 1, q-2, congruence)
+	tt
 end,
 function (tt::Cyclotomic)
 	nesum(tt, a, 1, q-2, congruence)
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	nesum(tt, a, 1, q-2, congruence)
 end,
 function (tt::Cyclotomic)
-	ss5a,e1=nesum(tt, a, 1, q-2, congruence)
-	ss5,e2=nesum(ss5a, b, 1, q-2, congruence)
+	tt
+end,
+function (tt::Cyclotomic)
+	ss5a=nesum(tt, a, 1, q-2, congruence)
+	ss5=nesum(ss5a, b, 1, q-2, congruence)
 	tt1=eesubs(tt, [b], [a])
-	ss6,e3=nesum(tt1, a, 1, q-2, congruence)
+	ss6=nesum(tt1, a, 1, q-2, congruence)
 	ss7=eesubs(tt, [a,b], S.([(q-1)*1//3,2*(q-1)*1//3]))
-	(1//6*ss5-1//6*ss6-1//3*ss7, union(e1,e2,e3))
+	1//6*ss5-1//6*ss6-1//3*ss7
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, a, 0, q^2-2, congruence)
+	ss7=nesum(tt, a, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	ss8,e2=nesum(tt1, a, 0, q-2, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, a, 0, q-2, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
 	nesum(tt, a, 1, 2, congruence)
 end,
 function (tt::Cyclotomic)
-	ss10,e1=nesum(tt, a, 0, q^2+q, congruence)
+	ss10=nesum(tt, a, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [a], [(q^2+q+1)*1//3*a])
-	ss11,e2=nesum(tt1, a, 0, 2, congruence)
-	(1//3*ss10-1//3*ss11, union(e1,e2))
+	ss11=nesum(tt1, a, 0, 2, congruence)
+	1//3*ss10-1//3*ss11
 end
 ]
 
@@ -176,41 +176,41 @@ function (tt::Cyclotomic)
 	nesum(tt, n, 0, 2, congruence)
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, n, 1, q-2, congruence)
+	ss6=nesum(tt, n, 1, q-2, congruence)
 	tt1=eesubs(tt, [n], [(q-1)*1//3])
 	tt2=eesubs(tt, [n], [2*(q-1)*1//3])
-	(ss6-tt1-tt2, e1)
+	ss6-tt1-tt2
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, n, 1, q-2, congruence)
+	ss6=nesum(tt, n, 1, q-2, congruence)
 	tt1=eesubs(tt, [n], [(q-1)*1//3])
 	tt2=eesubs(tt, [n], [2*(q-1)*1//3])
-	(ss6-tt1-tt2, e1)
+	ss6-tt1-tt2
 end,
 function (tt::Cyclotomic)
-	ss5,e1=nesum(tt, n, 0, q-2, congruence)
-	ss8,e2=nesum(ss5, m, 0, q-2, congruence)
+	ss5=nesum(tt, n, 0, q-2, congruence)
+	ss8=nesum(ss5, m, 0, q-2, congruence)
 	tt1=eesubs(tt, [m], [-2*n])
-	ss9,e3=nesum(tt1, n, 0, q-2, congruence)
+	ss9=nesum(tt1, n, 0, q-2, congruence)
 	tt1=eesubs(tt, [n], [-2*m])
-	ss10,e4=nesum(tt1, m, 0, q-2, congruence)
+	ss10=nesum(tt1, m, 0, q-2, congruence)
 	tt1=eesubs(tt, [m], [n])
-	ss11,e5=nesum(tt1, n, 0, q-2, congruence)
+	ss11=nesum(tt1, n, 0, q-2, congruence)
 	tt1=eesubs(tt1, [n], [(q-1)*1//3*n])
-	ss12,e6=nesum(tt1, n, 0, 2, congruence)
-	(1//6*ss8-1//6*ss9-1//6*ss10-1//6*ss11+1//3*ss12, union(e1,e2,e3,e4,e5,e6))
+	ss12=nesum(tt1, n, 0, 2, congruence)
+	1//6*ss8-1//6*ss9-1//6*ss10-1//6*ss11+1//3*ss12
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, n, 0, q^2-2, congruence)
+	ss7=nesum(tt, n, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [n], [(q+1)*n])
-	ss8,e2=nesum(tt1, n, 0, q-2, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, n, 0, q-2, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	s10,e1=nesum(tt, n, 1, q^2+q, congruence)
+	s10=nesum(tt, n, 1, q^2+q, congruence)
 	tt1=eesubs(tt, [n], [(q^2+q+1)*1//3])
 	tt2=eesubs(tt, [n], [2*(q^2+q+1)*1//3])
-	(1//3*s10-1//3*tt1-1//3*tt2, e1)
+	1//3*s10-1//3*tt1-1//3*tt2
 end
 ]
 

--- a/src/Tables/A2/PSL3.1.jl
+++ b/src/Tables/A2/PSL3.1.jl
@@ -180,107 +180,107 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, a, 1, q-2, congruence)
+	ss6=nesum(tt, a, 1, q-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*1//3])
 	tt2=eesubs(tt, [a], [2*(q-1)*1//3])
-	(1//3*ss6-1//3*tt1-1//3*tt2, e1)
+	1//3*ss6-1//3*tt1-1//3*tt2
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, a, 1, (q-2), congruence)
+	ss6=nesum(tt, a, 1, (q-2), congruence)
 	tt1=eesubs(tt, [a], [(q-1)*1//3])
 	tt2=eesubs(tt, [a], [2*(q-1)*1//3])
-	(1//3*ss6-1//3*tt1-1//3*tt2, e1)
+	1//3*ss6-1//3*tt1-1//3*tt2
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	ss5,e1=nesum(tt, a, 0, q-2, congruence)
-	ss8,e2=nesum(ss5, b, 0, q-2, congruence)
+	ss5=nesum(tt, a, 0, q-2, congruence)
+	ss8=nesum(ss5, b, 0, q-2, congruence)
 	tt1=eesubs(tt, [b], [a])
-	ss9,e3=nesum(tt1, a, 0, q-2, congruence)
+	ss9=nesum(tt1, a, 0, q-2, congruence)
 	tt2=eesubs(tt1, [a], [(q-1)*1//3*a])
-	ss10,e4=nesum(tt2, a, 0, 2, congruence)
+	ss10=nesum(tt2, a, 0, 2, congruence)
 	tt5=eesubs(tt, [b], [a+(q-1)*1//3])
 	tt4=eesubs(tt5, [a], [(q-1)*1//3*a])
-	ss11,e5=nesum(tt4, a, 0, 2, congruence)
-	(1//18*ss8-1//6*ss9+1//9*ss10-1//9*ss11, union(e1,e2,e3,e4,e5))
+	ss11=nesum(tt4, a, 0, 2, congruence)
+	1//18*ss8-1//6*ss9+1//9*ss10-1//9*ss11
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, a, 0, q^2-2, congruence)
+	ss7=nesum(tt, a, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	ss8,e2=nesum(tt1, a, 0, q-2, congruence)
-	(1//6*ss7-1//6*ss8, union(e1,e2))
+	ss8=nesum(tt1, a, 0, q-2, congruence)
+	1//6*ss7-1//6*ss8
 end,
 function (tt::Cyclotomic)
-	ss10,e1=nesum(tt, a, 0, q^2+q, congruence)
+	ss10=nesum(tt, a, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [a], [(q^2+q+1)*1//3*a])
-	ss11,e2=nesum(tt1, a, 0, 2, congruence)
-	(1//9*ss10-1//9*ss11, union(e1,e2))
+	ss11=nesum(tt1, a, 0, 2, congruence)
+	1//9*ss10-1//9*ss11
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
-end,
-function (tt::Cyclotomic)
-	nesum(tt, n, 1, (q-4)*1//3, congruence)
+	tt
 end,
 function (tt::Cyclotomic)
 	nesum(tt, n, 1, (q-4)*1//3, congruence)
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	nesum(tt, n, 1, (q-4)*1//3, congruence)
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	ss5a,e1=nesum(tt, m, 1, q-2, congruence)
-	ss5,e2=nesum(ss5a, n, 1, (q-1)*1//3, congruence)
+	tt
+end,
+function (tt::Cyclotomic)
+	ss5a=nesum(tt, m, 1, q-2, congruence)
+	ss5=nesum(ss5a, n, 1, (q-1)*1//3, congruence)
 	tt1=eesubs(tt, [n], [2*n])
 	tt2=eesubs(tt1, [m], [3*n])
-	ss6,e3=nesum(tt2, n, 1, (q-4)*1//3, congruence)
+	ss6=nesum(tt2, n, 1, (q-4)*1//3, congruence)
 	tt3=eesubs(tt, [m], [3*n])
-	ss8,e4=nesum(tt3, n, 1, (q-4)*1//3, congruence)
+	ss8=nesum(tt3, n, 1, (q-4)*1//3, congruence)
 	ss7=eesubs(tt, [m,n], [(q-1)*1//3,(q-1)*1//3])
-	(1//6*ss5-1//6*ss6-1//6*ss8-1//3*ss7, union(e1,e2,e3,e4))
+	1//6*ss5-1//6*ss6-1//6*ss8-1//3*ss7
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, n, 0, (q^2-4)*1//3, congruence)
+	ss7=nesum(tt, n, 0, (q^2-4)*1//3, congruence)
 	tt1=eesubs(tt, [n], [(q+1)*n])
-	ss8,e2=nesum(tt1, n, 0, (q-4)*1//3, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, n, 0, (q-4)*1//3, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, n, 0, (q^2+q-2)*1//3, congruence)
+	ss8=nesum(tt, n, 0, (q^2+q-2)*1//3, congruence)
 	tt1=eesubs(tt, [n], [0])
-	(1//3*ss8-1//3*tt1, e1)
+	1//3*ss8-1//3*tt1
 end
 ]
 

--- a/src/Tables/A2/SL3.1.jl
+++ b/src/Tables/A2/SL3.1.jl
@@ -254,102 +254,102 @@ function (tt::Cyclotomic)
 	nesum(tt, a, 0, 2, congruence)
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, a, 1, q-2, congruence)
+	ss6=nesum(tt, a, 1, q-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*1//3])
 	tt2=eesubs(tt, [a], [2*(q-1)*1//3])
-	(ss6-tt1-tt2, e1)
+	ss6-tt1-tt2
 end,
 function (tt::Cyclotomic)
-	ss6,e1=nesum(tt, a, 1, q-2, congruence)
+	ss6=nesum(tt, a, 1, q-2, congruence)
 	tt1=eesubs(tt, [a], [(q-1)*1//3])
 	tt2=eesubs(tt, [a], [2*(q-1)*1//3])
-	(ss6-tt1-tt2, e1)
+	ss6-tt1-tt2
 end,
 function (tt::Cyclotomic)
-	ss5,e1=nesum(tt, a, 0, q-2, congruence)
-	ss8,e2=nesum(ss5, b, 0, q-2, congruence)
+	ss5=nesum(tt, a, 0, q-2, congruence)
+	ss8=nesum(ss5, b, 0, q-2, congruence)
 	tt1=eesubs(tt, [b], [a])
-	ss9,e3=nesum(tt1, a, 0, q-2, congruence)
+	ss9=nesum(tt1, a, 0, q-2, congruence)
 	tt2=eesubs(tt1, [a], [(q-1)*1//3*a])
-	ss10,e4=nesum(tt2, a, 0, 2, congruence)
-	(1//6*ss8-1//2*ss9+1//3*ss10, union(e1,e2,e3,e4))
+	ss10=nesum(tt2, a, 0, 2, congruence)
+	1//6*ss8-1//2*ss9+1//3*ss10
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, a, 0, q^2-2, congruence)
+	ss7=nesum(tt, a, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	ss8,e2=nesum(tt1, a, 0, q-2, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, a, 0, q-2, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	ss10,e1=nesum(tt, a, 0, q^2+q, congruence)
+	ss10=nesum(tt, a, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [a], [(q^2+q+1)*1//3*a])
-	ss11,e2=nesum(tt1, a, 0, 2, congruence)
-	(1//3*ss10-1//3*ss11, union(e1,e2))
+	ss11=nesum(tt1, a, 0, 2, congruence)
+	1//3*ss10-1//3*ss11
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
-end,
-function (tt::Cyclotomic)
-	nesum(tt, n, 1, q-2, congruence)
+	tt
 end,
 function (tt::Cyclotomic)
 	nesum(tt, n, 1, q-2, congruence)
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	nesum(tt, n, 1, q-2, congruence)
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	ss5a,e1=nesum(tt, n, 1, q-2, congruence)
-	ss5,e2=nesum(ss5a, m, 1, q-2, congruence)
+	tt
+end,
+function (tt::Cyclotomic)
+	ss5a=nesum(tt, n, 1, q-2, congruence)
+	ss5=nesum(ss5a, m, 1, q-2, congruence)
 	tt1=eesubs(tt, [m], [n])
-	ss6,e3=nesum(tt1, n, 1, q-2, congruence)
+	ss6=nesum(tt1, n, 1, q-2, congruence)
 	ss7=eesubs(tt, [m,n], [(q-1)*1//3,2*(q-1)*1//3])
-	(1//6*ss5-1//6*ss6-1//3*ss7, union(e1,e2,e3))
+	1//6*ss5-1//6*ss6-1//3*ss7
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, n, 0, q^2-2, congruence)
+	ss7=nesum(tt, n, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [n], [(q+1)*n])
-	ss8,e2=nesum(tt1, n, 0, q-2, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, n, 0, q-2, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, n, 0, q^2+q, congruence)
+	ss8=nesum(tt, n, 0, q^2+q, congruence)
 	tt1=eesubs(tt, [n], [(q^2+q+1)*1//3*n])
-	ss9,e2=nesum(tt1, n, 0, 2, congruence)
-	(1//3*ss8-1//3*ss9, union(e1,e2))
+	ss9=nesum(tt1, n, 0, 2, congruence)
+	1//3*ss8-1//3*ss9
 end
 ]
 

--- a/src/Tables/A2/SL3.n1.jl
+++ b/src/Tables/A2/SL3.n1.jl
@@ -103,72 +103,72 @@ chardegree = R.([1, q^2+q, q^3, q^2+q+1, q*(q^2+q+1), (q+1)*(q^2+q+1), (q-1)*(q^
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
-end,
-function (tt::Cyclotomic)
-	nesum(tt, a, 1, q-2, congruence)
+	tt
 end,
 function (tt::Cyclotomic)
 	nesum(tt, a, 1, q-2, congruence)
 end,
 function (tt::Cyclotomic)
-	ss5,e1=nesum(tt, a, 0, q-2, congruence)
-	ss6,e2=nesum(ss5, b, 0, q-2, congruence)
+	nesum(tt, a, 1, q-2, congruence)
+end,
+function (tt::Cyclotomic)
+	ss5=nesum(tt, a, 0, q-2, congruence)
+	ss6=nesum(ss5, b, 0, q-2, congruence)
 	tt1=eesubs(tt, [b], [a])
-	ss7,e3=nesum(tt1, a, 0, q-2, congruence)
+	ss7=nesum(tt1, a, 0, q-2, congruence)
 	tt2=eesubs(tt1, [a], [0])
-	(1//6*ss6-1//2*ss7+1//3*tt2, union(e1,e2,e3))
+	1//6*ss6-1//2*ss7+1//3*tt2
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, a, 0, q^2-2, congruence)
+	ss7=nesum(tt, a, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [a], [(q+1)*a])
-	ss8,e2=nesum(tt1, a, 0, q-2, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, a, 0, q-2, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, a, 1, q^2+q, congruence)
-	(1//3*ss8, e1)
+	ss8=nesum(tt, a, 1, q^2+q, congruence)
+	1//3*ss8
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
-end,
-function (tt::Cyclotomic)
-	nesum(tt, n, 1, q-2, congruence)
+	tt
 end,
 function (tt::Cyclotomic)
 	nesum(tt, n, 1, q-2, congruence)
 end,
 function (tt::Cyclotomic)
-	ss5,e1=nesum(tt, n, 1, q-2, congruence)
-	ss6,e2=nesum(ss5, m, 1, q-2, congruence)
+	nesum(tt, n, 1, q-2, congruence)
+end,
+function (tt::Cyclotomic)
+	ss5=nesum(tt, n, 1, q-2, congruence)
+	ss6=nesum(ss5, m, 1, q-2, congruence)
 	tt1=eesubs(tt, [m], [n])
-	ss7,e3=nesum(tt1, n, 1, q-2, congruence)
-	(1//6*ss6-1//6*ss7, union(e1,e2,e3))
+	ss7=nesum(tt1, n, 1, q-2, congruence)
+	1//6*ss6-1//6*ss7
 end,
 function (tt::Cyclotomic)
-	ss7,e1=nesum(tt, n, 0, q^2-2, congruence)
+	ss7=nesum(tt, n, 0, q^2-2, congruence)
 	tt1=eesubs(tt, [n], [(q+1)*n])
-	ss8,e2=nesum(tt1, n, 0, q-2, congruence)
-	(1//2*ss7-1//2*ss8, union(e1,e2))
+	ss8=nesum(tt1, n, 0, q-2, congruence)
+	1//2*ss7-1//2*ss8
 end,
 function (tt::Cyclotomic)
-	ss8,e1=nesum(tt, n, 1, q^2+q, congruence)
-	(1//3*ss8, e1)
+	ss8=nesum(tt, n, 1, q^2+q, congruence)
+	1//3*ss8
 end
 ]
 

--- a/src/Tables/C2/Sp4.0.jl
+++ b/src/Tables/C2/Sp4.0.jl
@@ -452,173 +452,173 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [j], [i])
 	s2=eesubs(tt, [j], [-i])
-	s3,e1=nesum(tt, j, 1, q-2, congruence)
+	s3=nesum(tt, j, 1, q-2, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, i, 1, q-2, congruence)
-	(1//8*s3, union(e1,e2))
+	s3=nesum(s3, i, 1, q-2, congruence)
+	1//8*s3
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i], [(q-1)*i])
-	s1,e1=nesum(s1, i, 1, q, congruence)
+	s1=nesum(s1, i, 1, q, congruence)
 	s2=eesubs(tt, [i], [(q+1)*i])
-	s2,e2=nesum(s2, i, 1, q-2, congruence)
-	s3,e3=nesum(tt, i, 1, q^2-2, congruence)
-	(1//4*s3-1//4*s2-1//4*s1, union(e1,e2,e3))
+	s2=nesum(s2, i, 1, q-2, congruence)
+	s3=nesum(tt, i, 1, q^2-2, congruence)
+	1//4*s3-1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, j, 1, q, congruence)
-	s1,e2=nesum(s1, i, 1, q-2, congruence)
-	(1//4*s1, union(e1,e2))
+	s1=nesum(tt, j, 1, q, congruence)
+	s1=nesum(s1, i, 1, q-2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, i, 1, q^2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [j], [i])
 	s2=eesubs(tt, [j], [-i])
-	s3,e1=nesum(tt, j, 1, q, congruence)
+	s3=nesum(tt, j, 1, q, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, i, 1, q, congruence)
-	(1//8*s3, union(e1,e2))
+	s3=nesum(s3, i, 1, q, congruence)
+	1//8*s3
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [l], [k])
 	s2=eesubs(tt, [l], [-k])
-	s3,e1=nesum(tt, l, 1, q-2, congruence)
+	s3=nesum(tt, l, 1, q-2, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, k, 1, q-2, congruence)
-	(1//8*s3, union(e1,e2))
+	s3=nesum(s3, k, 1, q-2, congruence)
+	1//8*s3
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k], [(q-1)*k])
-	s1,e1=nesum(s1, k, 1, q, congruence)
+	s1=nesum(s1, k, 1, q, congruence)
 	s2=eesubs(tt, [k], [(q+1)*k])
-	s2,e2=nesum(s2, k, 1, q-2, congruence)
-	s3,e3=nesum(tt, k, 1, q^2-2, congruence)
-	(1//4*s3-1//4*s2-1//4*s1, union(e1,e2,e3))
+	s2=nesum(s2, k, 1, q-2, congruence)
+	s3=nesum(tt, k, 1, q^2-2, congruence)
+	1//4*s3-1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, l, 1, q, congruence)
-	s1,e2=nesum(s1, k, 1, q-2, congruence)
-	(1//4*s1, union(e1,e2))
+	s1=nesum(tt, l, 1, q, congruence)
+	s1=nesum(s1, k, 1, q-2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, k, 1, q^2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [l], [k])
 	s2=eesubs(tt, [l], [-k])
-	s3,e1=nesum(tt, l, 1, q, congruence)
+	s3=nesum(tt, l, 1, q, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, k, 1, q, congruence)
-	(1//8*s3, union(e1,e2))
+	s3=nesum(s3, k, 1, q, congruence)
+	1//8*s3
 end
 ]
 

--- a/src/Tables/C3/CSp6.1.jl
+++ b/src/Tables/C3/CSp6.1.jl
@@ -9463,604 +9463,604 @@ end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i2], [2*i11])
-	zw1,e2=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e3=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q-2, congruence)
 	zw2=eesubs(zw2, [i2], [2*i11+1])
-	zw2,e4=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//2*zw1+1//2*zw2, union(e1,e2,e3,e4))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//2*zw1+1//2*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i2], [2*i11])
-	zw1,e2=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e3=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q-2, congruence)
 	zw2=eesubs(zw2, [i2], [2*i11+1])
-	zw2,e4=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//2*zw1+1//2*zw2, union(e1,e2,e3,e4))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//2*zw1+1//2*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i2], [2*i11])
-	zw1,e2=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e3=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q-2, congruence)
 	zw2=eesubs(zw2, [i2], [2*i11+1])
-	zw2,e4=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//2*zw1+1//2*zw2, union(e1,e2,e3,e4))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//2*zw1+1//2*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i2], [2*i11])
-	zw1,e2=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e3=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q, congruence)
 	zw2=eesubs(zw2, [i2], [2*i11+1])
-	zw2,e4=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//2*zw1+1//2*zw2, union(e1,e2,e3,e4))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//2*zw1+1//2*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i2], [2*i11])
-	zw1,e2=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e3=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q, congruence)
 	zw2=eesubs(zw2, [i2], [2*i11+1])
-	zw2,e4=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//2*zw1+1//2*zw2, union(e1,e2,e3,e4))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//2*zw1+1//2*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i2], [2*i11])
-	zw1,e2=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e3=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q, congruence)
 	zw2=eesubs(zw2, [i2], [2*i11+1])
-	zw2,e4=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//2*zw1+1//2*zw2, union(e1,e2,e3,e4))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//2*zw1+1//2*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i2], [i1])
 	s2=eesubs(tt, [i2], [i1+1//2*q-1//2])
-	zw1,e1=nesum(tt, i2, 0, q-2, congruence)
+	zw1=nesum(tt, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i2], [i1])
 	s2=eesubs(tt, [i2], [i1+1//2*q-1//2])
-	zw1,e1=nesum(tt, i2, 0, q-2, congruence)
+	zw1=nesum(tt, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i2], [i1])
 	s2=eesubs(tt, [i2], [i1+1//2*q-1//2])
-	zw1,e1=nesum(tt, i2, 0, q-2, congruence)
+	zw1=nesum(tt, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i2], [i1])
 	s2=eesubs(tt, [i2], [i1+1//2*q-1//2])
-	zw1,e1=nesum(tt, i2, 0, q-2, congruence)
+	zw1=nesum(tt, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i2], [i1])
 	s2=eesubs(tt, [i2], [i1+1//2*q-1//2])
-	zw1,e1=nesum(tt, i2, 0, q-2, congruence)
+	zw1=nesum(tt, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i2], [i1])
 	s2=eesubs(tt, [i2], [i1+1//2*q+1//2])
-	zw1,e1=nesum(tt, i2, 0, q, congruence)
+	zw1=nesum(tt, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i2], [i1])
 	s2=eesubs(tt, [i2], [i1+1//2*q+1//2])
-	zw1,e1=nesum(tt, i2, 0, q, congruence)
+	zw1=nesum(tt, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i2], [i1])
 	s2=eesubs(tt, [i2], [i1+1//2*q+1//2])
-	zw1,e1=nesum(tt, i2, 0, q, congruence)
+	zw1=nesum(tt, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i2], [i1])
 	s2=eesubs(tt, [i2], [i1+1//2*q+1//2])
-	zw1,e1=nesum(tt, i2, 0, q, congruence)
+	zw1=nesum(tt, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i2], [i1])
 	s2=eesubs(tt, [i2], [i1+1//2*q+1//2])
-	zw1,e1=nesum(tt, i2, 0, q, congruence)
+	zw1=nesum(tt, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [i2+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//2*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i2, 0, q-2, congruence)
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i2, 0, q-2, congruence)
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i2, 0, q-2, congruence)
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i2, 0, q, congruence)
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i2, 0, q, congruence)
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i2, 0, q, congruence)
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i2, 0, q, congruence)
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i2, 0, q, congruence)
-	zw1,e2=nesum(zw1, i1, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i2, 0, q, congruence)
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i3])
 	s2=eesubs(tt, [i1], [i3+1//2*q-1//2])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [2*i3-i2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [i3])
 	s2=eesubs(zw1, [i2], [i3+1//2*q-1//2])
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e3=nesum(zw1, i3, 0, q-2, congruence)
-	(1//8*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i3, 0, q-2, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i3])
 	s2=eesubs(tt, [i1], [i3+1//2*q-1//2])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [2*i3-i2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [i3])
 	s2=eesubs(zw1, [i2], [i3+1//2*q-1//2])
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e3=nesum(zw1, i3, 0, q-2, congruence)
-	(1//8*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i3, 0, q-2, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q-1//2])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [2*i11-i2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q-1//2])
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e3=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [2*i11+1-i2])
-	zw2,e4=nesum(tt, i1, 0, q-2, congruence)
+	zw2=nesum(tt, i1, 0, q-2, congruence)
 	zw2=zw2-s1-s2
-	zw2,e5=nesum(zw2, i2, 0, q-2, congruence)
+	zw2=nesum(zw2, i2, 0, q-2, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e6=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//4*zw1+1//4*zw2, union(e1,e2,e3,e4,e5,e6))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//4*zw1+1//4*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q-1//2])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [2*i11-i2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q-1//2])
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e3=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [2*i11+1-i2])
-	zw2,e4=nesum(tt, i1, 0, q-2, congruence)
+	zw2=nesum(tt, i1, 0, q-2, congruence)
 	zw2=zw2-s1-s2
-	zw2,e5=nesum(zw2, i2, 0, q-2, congruence)
+	zw2=nesum(zw2, i2, 0, q-2, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e6=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//4*zw1+1//4*zw2, union(e1,e2,e3,e4,e5,e6))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//4*zw1+1//4*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i3])
 	s2=eesubs(tt, [i1], [i3+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	s1=eesubs(zw1, [i2], [i3])
 	s2=eesubs(zw1, [i2], [i3+1//2*q+1//2])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e3=nesum(zw1, i3, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i3, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i3])
 	s2=eesubs(tt, [i1], [i3+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	s1=eesubs(zw1, [i2], [i3])
 	s2=eesubs(zw1, [i2], [i3+1//2*q+1//2])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e3=nesum(zw1, i3, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i3, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q+1)])
 	s2=eesubs(tt, [i1], [2*i2+i1*(q-1)])
 	s3=eesubs(tt, [i1], [i2*(q+1)])
 	s4=eesubs(tt, [i1], [i2*(q+1)+1//2*q^2-1//2])
-	s1,e1=nesum(s1, i1, 0, q-2, congruence)
-	s2,e2=nesum(s2, i1, 0, q, congruence)
-	zw1,e3=nesum(tt, i1, 0, q^2-2, congruence)
+	s1=nesum(s1, i1, 0, q-2, congruence)
+	s2=nesum(s2, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q^2-2, congruence)
 	zw1=zw1-s1-s2+s3+s4
-	zw1,e4=nesum(zw1, i2, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2,e3,e4))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q+1)])
 	s2=eesubs(tt, [i1], [2*i2+i1*(q-1)])
 	s3=eesubs(tt, [i1], [i2*(q+1)])
 	s4=eesubs(tt, [i1], [i2*(q+1)+1//2*q^2-1//2])
-	s1,e1=nesum(s1, i1, 0, q-2, congruence)
-	s2,e2=nesum(s2, i1, 0, q, congruence)
-	zw1,e3=nesum(tt, i1, 0, q^2-2, congruence)
+	s1=nesum(s1, i1, 0, q-2, congruence)
+	s2=nesum(s2, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q^2-2, congruence)
 	zw1=zw1-s1-s2+s3+s4
-	zw1,e4=nesum(zw1, i2, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2,e3,e4))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q+1//2])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e3=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e4=nesum(tt, i1, 0, q-2, congruence)
-	zw2,e5=nesum(zw2, i2, 0, q, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q-2, congruence)
+	zw2=nesum(zw2, i2, 0, q, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e6=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//4*zw1+1//4*zw2, union(e1,e2,e3,e4,e5,e6))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//4*zw1+1//4*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q+1//2])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e3=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e4=nesum(tt, i1, 0, q-2, congruence)
-	zw2,e5=nesum(zw2, i2, 0, q, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q-2, congruence)
+	zw2=nesum(zw2, i2, 0, q, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e6=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//4*zw1+1//4*zw2, union(e1,e2,e3,e4,e5,e6))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//4*zw1+1//4*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q-1//2])
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e3=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e4=nesum(tt, i1, 0, q, congruence)
-	zw2,e5=nesum(zw2, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q, congruence)
+	zw2=nesum(zw2, i2, 0, q-2, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e6=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//4*zw1+1//4*zw2, union(e1,e2,e3,e4,e5,e6))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//4*zw1+1//4*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q+1//2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q-1//2])
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e3=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e4=nesum(tt, i1, 0, q, congruence)
-	zw2,e5=nesum(zw2, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q, congruence)
+	zw2=nesum(zw2, i2, 0, q-2, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e6=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//4*zw1+1//4*zw2, union(e1,e2,e3,e4,e5,e6))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//4*zw1+1//4*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i3])
 	s2=eesubs(tt, [i1], [i3+1//2*q+1//2])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [2*i3-i2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [i3])
 	s2=eesubs(zw1, [i2], [i3+1//2*q+1//2])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e3=nesum(zw1, i3, 0, q-2, congruence)
-	(1//8*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i3, 0, q-2, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i3])
 	s2=eesubs(tt, [i1], [i3+1//2*q+1//2])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [2*i3-i2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [i3])
 	s2=eesubs(zw1, [i2], [i3+1//2*q+1//2])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e3=nesum(zw1, i3, 0, q-2, congruence)
-	(1//8*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i3, 0, q-2, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2*(q+1)])
 	s2=eesubs(tt, [i1], [i2*(q+1)+1//2*q^2+1//2])
-	zw1,e1=nesum(tt, i1, 0, q^2, congruence)
+	zw1=nesum(tt, i1, 0, q^2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2*(q+1)])
 	s2=eesubs(tt, [i1], [i2*(q+1)+1//2*q^2+1//2])
-	zw1,e1=nesum(tt, i1, 0, q^2, congruence)
+	zw1=nesum(tt, i1, 0, q^2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [-i11])
 	s2=eesubs(tt, [i1], [-i11+1//2*q+1//2])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [-i3-i2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [-i11])
 	s2=eesubs(zw1, [i2], [-i11+1//2*q+1//2])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e3=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [-i3-i2])
-	zw2,e4=nesum(tt, i1, 0, q, congruence)
+	zw2=nesum(tt, i1, 0, q, congruence)
 	zw2=zw2-s1-s2
-	zw2,e5=nesum(zw2, i2, 0, q, congruence)
+	zw2=nesum(zw2, i2, 0, q, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e6=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//4*zw1+1//4*zw2, union(e1,e2,e3,e4,e5,e6))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//4*zw1+1//4*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [-i11])
 	s2=eesubs(tt, [i1], [-i11+1//2*q+1//2])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [-i3-i2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [-i11])
 	s2=eesubs(zw1, [i2], [-i11+1//2*q+1//2])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e3=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [-i3-i2])
-	zw2,e4=nesum(tt, i1, 0, q, congruence)
+	zw2=nesum(tt, i1, 0, q, congruence)
 	zw2=zw2-s1-s2
-	zw2,e5=nesum(zw2, i2, 0, q, congruence)
+	zw2=nesum(zw2, i2, 0, q, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e6=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//4*zw1+1//4*zw2, union(e1,e2,e3,e4,e5,e6))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//4*zw1+1//4*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i3], [i11])
@@ -10069,172 +10069,172 @@ function (tt::Cyclotomic)
 	s4=eesubs(tt, [i3], [2*i11-i1])
 	s5=eesubs(tt, [i3], [i2])
 	s6=eesubs(tt, [i3], [2*i11-i2])
-	zw1,e1=nesum(tt, i3, 0, q-2, congruence)
+	zw1=nesum(tt, i3, 0, q-2, congruence)
 	zw1=zw1-s1-s2-s3-s4-s5-s6
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q-1//2])
 	s3=eesubs(zw1, [i2], [i1])
 	s4=eesubs(zw1, [i2], [2*i11-i1])
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i1], [i11])
 	s2=eesubs(zw1, [i1], [i11+1//2*q-1//2])
-	zw1,e3=nesum(zw1, i1, 0, q-2, congruence)
+	zw1=nesum(zw1, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i4], [2*i11])
-	zw1,e4=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
 	s1=eesubs(tt, [i3], [i1])
 	s2=eesubs(tt, [i3], [2*i11+1-i1])
 	s3=eesubs(tt, [i3], [i2])
 	s4=eesubs(tt, [i3], [2*i11+1-i2])
-	zw2,e5=nesum(tt, i3, 0, q-2, congruence)
+	zw2=nesum(tt, i3, 0, q-2, congruence)
 	zw2=zw2-s1-s2-s3-s4
 	s1=eesubs(zw2, [i2], [i1])
 	s2=eesubs(zw2, [i2], [2*i11+1-i1])
-	zw2,e6=nesum(zw2, i2, 0, q-2, congruence)
+	zw2=nesum(zw2, i2, 0, q-2, congruence)
 	zw2=zw2-s1-s2
-	zw2,e7=nesum(zw2, i1, 0, q-2, congruence)
+	zw2=nesum(zw2, i1, 0, q-2, congruence)
 	zw2=eesubs(zw2, [i4], [2*i11+1])
-	zw2,e8=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//48*zw1+1//48*zw2, union(e1,e2,e3,e4,e5,e6,e7,e8))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//48*zw1+1//48*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q-1//2])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [2*i11-i2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q-1//2])
-	zw1,e2=nesum(zw1, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	s1=eesubs(zw1, [i3], [i11])
 	s2=eesubs(zw1, [i3], [i11+1//2*q+1//2])
-	zw1,e3=nesum(zw1, i3, 0, q, congruence)
+	zw1=nesum(zw1, i3, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i4], [2*i11])
-	zw1,e4=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [2*i11+1-i2])
-	zw2,e5=nesum(tt, i1, 0, q-2, congruence)
+	zw2=nesum(tt, i1, 0, q-2, congruence)
 	zw2=zw2-s1-s2
-	zw2,e6=nesum(zw2, i2, 0, q-2, congruence)
-	zw2,e7=nesum(zw2, i3, 0, q, congruence)
+	zw2=nesum(zw2, i2, 0, q-2, congruence)
+	zw2=nesum(zw2, i3, 0, q, congruence)
 	zw2=eesubs(zw2, [i4], [2*i11+1])
-	zw2,e8=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//16*zw1+1//16*zw2, union(e1,e2,e3,e4,e5,e6,e7,e8))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//16*zw1+1//16*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q+1)])
 	s2=eesubs(tt, [i1], [2*i11+i1*(q-1)])
 	s3=eesubs(tt, [i1], [i11*(q+1)])
 	s4=eesubs(tt, [i1], [i11*(q+1)+1//2*q^2-1//2])
-	s1,e1=nesum(s1, i1, 0, q-2, congruence)
-	s2,e2=nesum(s2, i1, 0, q, congruence)
-	zw1,e3=nesum(tt, i1, 0, q^2-2, congruence)
+	s1=nesum(s1, i1, 0, q-2, congruence)
+	s2=nesum(s2, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q^2-2, congruence)
 	zw1=zw1-s1-s2+s3+s4
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q-1//2])
-	zw1,e4=nesum(zw1, i2, 0, q-2, congruence)
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e5=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
 	s1=eesubs(tt, [i1], [i1*(q+1)])
 	s2=eesubs(tt, [i1], [2*i11+1+i1*(q-1)])
 	s3=eesubs(tt, [i1], [1//2*(2*i11+1)*(q+1)])
 	s4=eesubs(tt, [i1], [1//2*(2*i11+1)*(q+1)+1//2*q^2-1//2])
-	s1,e6=nesum(s1, i1, 0, q-2, congruence)
-	s2,e7=nesum(s2, i1, 0, q, congruence)
-	zw2,e8=nesum(tt, i1, 0, q^2-2, congruence)
+	s1=nesum(s1, i1, 0, q-2, congruence)
+	s2=nesum(s2, i1, 0, q, congruence)
+	zw2=nesum(tt, i1, 0, q^2-2, congruence)
 	zw2=zw2-s1-s2-s3-s4
-	zw2,e9=nesum(zw2, i2, 0, q-2, congruence)
+	zw2=nesum(zw2, i2, 0, q-2, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e10=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//8*zw1+1//8*zw2, union(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//8*zw1+1//8*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q+1//2])
 	s3=eesubs(zw1, [i2], [i3])
 	s4=eesubs(zw1, [i2], [i4-i3])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i3], [i11])
 	s2=eesubs(zw1, [i3], [i11+1//2*q+1//2])
-	zw1,e3=nesum(zw1, i3, 0, q, congruence)
+	zw1=nesum(zw1, i3, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i4], [2*i11])
-	zw1,e4=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e5=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q-2, congruence)
 	s1=eesubs(zw2, [i2], [i3])
 	s2=eesubs(zw2, [i2], [i4-i3])
-	zw2,e6=nesum(zw2, i2, 0, q, congruence)
+	zw2=nesum(zw2, i2, 0, q, congruence)
 	zw2=zw2-s1-s2
-	zw2,e7=nesum(zw2, i3, 0, q, congruence)
+	zw2=nesum(zw2, i3, 0, q, congruence)
 	zw2=eesubs(zw2, [i4], [2*i11+1])
-	zw2,e8=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//16*zw1+1//16*zw2, union(e1,e2,e3,e4,e5,e6,e7,e8))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//16*zw1+1//16*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q+1)])
 	s2=eesubs(tt, [i1], [2*i11+i1*(q-1)])
 	s3=eesubs(tt, [i1], [i11*(q+1)])
 	s4=eesubs(tt, [i1], [i11*(q+1)+1//2*q^2-1//2])
-	s1,e1=nesum(s1, i1, 0, q-2, congruence)
-	s2,e2=nesum(s2, i1, 0, q, congruence)
-	zw1,e3=nesum(tt, i1, 0, q^2-2, congruence)
+	s1=nesum(s1, i1, 0, q-2, congruence)
+	s2=nesum(s2, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q^2-2, congruence)
 	zw1=zw1-s1-s2+s3+s4
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q+1//2])
-	zw1,e4=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e5=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
 	s1=eesubs(tt, [i1], [i1*(q+1)])
 	s2=eesubs(tt, [i1], [2*i11+1+i1*(q-1)])
 	s3=eesubs(tt, [i1], [1//2*(2*i11+1)*(q+1)])
 	s4=eesubs(tt, [i1], [1//2*(2*i11+1)*(q+1)+1//2*q^2-1//2])
-	s1,e6=nesum(s1, i1, 0, q-2, congruence)
-	s2,e7=nesum(s2, i1, 0, q, congruence)
-	zw2,e8=nesum(tt, i1, 0, q^2-2, congruence)
+	s1=nesum(s1, i1, 0, q-2, congruence)
+	s2=nesum(s2, i1, 0, q, congruence)
+	zw2=nesum(tt, i1, 0, q^2-2, congruence)
 	zw2=zw2-s1-s2-s3-s4
-	zw2,e9=nesum(zw2, i2, 0, q, congruence)
+	zw2=nesum(zw2, i2, 0, q, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e10=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//8*zw1+1//8*zw2, union(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//8*zw1+1//8*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i11])
 	s2=eesubs(tt, [i1], [i11+1//2*q-1//2])
-	zw1,e1=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q-2, congruence)
 	zw1=zw1-s1-s2
 	s1=eesubs(zw1, [i2], [1//2*i3*(q+1)])
 	s2=eesubs(zw1, [i2], [1//2*i3*(q+1)+1//2*q^2+1//2])
-	zw1,e2=nesum(zw1, i2, 0, q^2, congruence)
+	zw1=nesum(zw1, i2, 0, q^2, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e3=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
-	zw2,e4=nesum(tt, i1, 0, q-2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw2=nesum(tt, i1, 0, q-2, congruence)
 	s1=eesubs(zw2, [i2], [1//2*i3*(q+1)])
 	s2=eesubs(zw2, [i2], [1//2*i3*(q+1)+1//2*q^2+1//2])
-	zw2,e5=nesum(zw2, i2, 0, q^2, congruence)
+	zw2=nesum(zw2, i2, 0, q^2, congruence)
 	zw2=zw2-s1-s2
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e6=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//8*zw1+1//8*zw2, union(e1,e2,e3,e4,e5,e6))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//8*zw1+1//8*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q^2+q+1)])
-	s1,e1=nesum(s1, i1, 0, q-2, congruence)
-	zw1,e2=nesum(tt, i1, 0, q^3-2, congruence)
+	s1=nesum(s1, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q^3-2, congruence)
 	zw1=zw1-s1
-	zw1,e3=nesum(zw1, i2, 0, q-2, congruence)
-	(1//6*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//6*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [-i11])
@@ -10243,62 +10243,62 @@ function (tt::Cyclotomic)
 	s4=eesubs(tt, [i1], [-i4-i3])
 	s5=eesubs(tt, [i1], [i2])
 	s6=eesubs(tt, [i1], [-i4-i2])
-	zw1,e1=nesum(tt, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q, congruence)
 	zw1=zw1-s1-s2-s3-s4-s5-s6
 	s1=eesubs(zw1, [i2], [-i11])
 	s2=eesubs(zw1, [i2], [-i11+1//2*q+1//2])
 	s3=eesubs(zw1, [i2], [i3])
 	s4=eesubs(zw1, [i2], [-i4-i3])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i3], [-i11])
 	s2=eesubs(zw1, [i3], [-i11+1//2*q+1//2])
-	zw1,e3=nesum(zw1, i3, 0, q, congruence)
+	zw1=nesum(zw1, i3, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i4], [2*i11])
-	zw1,e4=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
 	s1=eesubs(tt, [i1], [i3])
 	s2=eesubs(tt, [i1], [-i4-i3])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [-i4-i2])
-	zw2,e5=nesum(tt, i1, 0, q, congruence)
+	zw2=nesum(tt, i1, 0, q, congruence)
 	zw2=zw2-s1-s2-s3-s4
 	s1=eesubs(zw2, [i2], [i3])
 	s2=eesubs(zw2, [i2], [-i4-i3])
-	zw2,e6=nesum(zw2, i2, 0, q, congruence)
+	zw2=nesum(zw2, i2, 0, q, congruence)
 	zw2=zw2-s1-s2
-	zw2,e7=nesum(zw2, i3, 0, q, congruence)
+	zw2=nesum(zw2, i3, 0, q, congruence)
 	zw2=eesubs(zw2, [i4], [2*i11+1])
-	zw2,e8=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//48*zw1+1//48*zw2, union(e1,e2,e3,e4,e5,e6,e7,e8))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//48*zw1+1//48*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [1//2*i3*(q+1)])
 	s2=eesubs(tt, [i1], [1//2*i3*(q+1)+1//2*q^2+1//2])
-	zw1,e1=nesum(tt, i1, 0, q^2, congruence)
+	zw1=nesum(tt, i1, 0, q^2, congruence)
 	zw1=zw1-s1-s2
 	s1=eesubs(zw1, [i2], [i11])
 	s2=eesubs(zw1, [i2], [i11+1//2*q+1//2])
-	zw1,e2=nesum(zw1, i2, 0, q, congruence)
+	zw1=nesum(zw1, i2, 0, q, congruence)
 	zw1=zw1-s1-s2
 	zw1=eesubs(zw1, [i3], [2*i11])
-	zw1,e3=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
+	zw1=nesum(zw1, i11, 0, 1//2*q-3//2, congruence)
 	s1=eesubs(tt, [i1], [1//2*i3*(q+1)])
 	s2=eesubs(tt, [i1], [1//2*i3*(q+1)+1//2*q^2+1//2])
-	zw2,e4=nesum(tt, i1, 0, q^2, congruence)
+	zw2=nesum(tt, i1, 0, q^2, congruence)
 	zw2=zw2-s1-s2
-	zw2,e5=nesum(zw2, i2, 0, q, congruence)
+	zw2=nesum(zw2, i2, 0, q, congruence)
 	zw2=eesubs(zw2, [i3], [2*i11+1])
-	zw2,e6=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
-	(1//8*zw1+1//8*zw2, union(e1,e2,e3,e4,e5,e6))
+	zw2=nesum(zw2, i11, 0, 1//2*q-3//2, congruence)
+	1//8*zw1+1//8*zw2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [q*i2+i1*(q^2-q+1)])
-	s1,e1=nesum(s1, i1, 0, q, congruence)
-	zw1,e2=nesum(tt, i1, 0, q^3, congruence)
+	s1=nesum(s1, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q^3, congruence)
 	zw1=zw1-s1
-	zw1,e3=nesum(zw1, i2, 0, q-2, congruence)
-	(1//6*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i2, 0, q-2, congruence)
+	1//6*zw1
 end
 ]
 
@@ -10340,623 +10340,623 @@ function (tt::Cyclotomic)
 	nesum(tt, k1, 0, q-2, congruence)
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 0, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 0, q-2, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 0, q-2, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 0, q-2, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 0, q-2, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 0, q-2, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 0, q-2, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k2, 0, q-2, congruence)
-	s1,e2=nesum(s1, k1, 1, q, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k2, 0, q-2, congruence)
+	s1=nesum(s1, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k2, 0, q-2, congruence)
-	s1,e2=nesum(s1, k1, 1, q, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k2, 0, q-2, congruence)
+	s1=nesum(s1, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k2, 0, q-2, congruence)
-	s1,e2=nesum(s1, k1, 1, q, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k2, 0, q-2, congruence)
+	s1=nesum(s1, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k2, 0, q-2, congruence)
-	s1,e2=nesum(s1, k1, 1, q, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k2, 0, q-2, congruence)
+	s1=nesum(s1, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k2, 0, q-2, congruence)
-	s1,e2=nesum(s1, k1, 1, q, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k2, 0, q-2, congruence)
+	s1=nesum(s1, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k2, 0, q-2, congruence)
-	s1,e2=nesum(s1, k1, 1, q, congruence)
-	(1//2*s1, union(e1,e2))
-end,
-function (tt::Cyclotomic)
-	s1=eesubs(tt, [k1], [1//2*q-1//2])
-	s2,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1=s2-s1
-	s1,e2=nesum(s1, k2, 0, q-2, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(tt, k2, 0, q-2, congruence)
+	s1=nesum(s1, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [1//2*q-1//2])
-	s2,e1=nesum(tt, k1, 1, q-2, congruence)
+	s2=nesum(tt, k1, 1, q-2, congruence)
 	s1=s2-s1
-	s1,e2=nesum(s1, k2, 0, q-2, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(s1, k2, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [1//2*q-1//2])
-	s2,e1=nesum(tt, k1, 1, q-2, congruence)
+	s2=nesum(tt, k1, 1, q-2, congruence)
 	s1=s2-s1
-	s1,e2=nesum(s1, k2, 0, q-2, congruence)
-	(1//2*s1, union(e1,e2))
+	s1=nesum(s1, k2, 0, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s1=eesubs(tt, [k1], [1//2*q-1//2])
+	s2=nesum(tt, k1, 1, q-2, congruence)
+	s1=s2-s1
+	s1=nesum(s1, k2, 0, q-2, congruence)
+	1//2*s1
+end,
+function (tt::Cyclotomic)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//2*s2-1//2*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//2*s2-1//2*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s5,e1=nesum(tt, k3, 0, q-2, congruence)
+	s5=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s5, [k1,k2], [1//2*q-1//2,1//2*q-1//2])
 	s2=eesubs(s5, [k1], [k2])
 	s3=eesubs(s5, [k1], [-k2])
 	s4=eesubs(s5, [k1], [1//2*q-1//2])
-	s5,e2=nesum(s5, k1, 1, q-2, congruence)
+	s5=nesum(s5, k1, 1, q-2, congruence)
 	s5=s5-s2-s3-s4
-	s5,e3=nesum(s5, k2, 1, q-2, congruence)
-	(1//4*s5+1//2*s1, union(e1,e2,e3))
+	s5=nesum(s5, k2, 1, q-2, congruence)
+	1//4*s5+1//2*s1
 end,
 function (tt::Cyclotomic)
-	s5,e1=nesum(tt, k3, 0, q-2, congruence)
+	s5=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s5, [k1,k2], [1//2*q-1//2,1//2*q-1//2])
 	s2=eesubs(s5, [k1], [k2])
 	s3=eesubs(s5, [k1], [-k2])
 	s4=eesubs(s5, [k1], [1//2*q-1//2])
-	s5,e2=nesum(s5, k1, 1, q-2, congruence)
+	s5=nesum(s5, k1, 1, q-2, congruence)
 	s5=s5-s2-s3-s4
-	s5,e3=nesum(s5, k2, 1, q-2, congruence)
-	(1//4*s5+1//2*s1, union(e1,e2,e3))
+	s5=nesum(s5, k2, 1, q-2, congruence)
+	1//4*s5+1//2*s1
 end,
 function (tt::Cyclotomic)
-	s4,e1=nesum(tt, k3, 0, q-2, congruence)
+	s4=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s4, [k1,k2], [1//2*q-1//2,1//2*q-1//2])
 	s2=eesubs(s4, [k1], [k2])
 	s3=eesubs(s4, [k1], [-k2])
-	s4,e2=nesum(s4, k1, 1, q-2, congruence)
+	s4=nesum(s4, k1, 1, q-2, congruence)
 	s4=s4-s2-s3
-	s4,e3=nesum(s4, k2, 1, q-2, congruence)
-	(1//8*s4+1//8*s1, union(e1,e2,e3))
+	s4=nesum(s4, k2, 1, q-2, congruence)
+	1//8*s4+1//8*s1
 end,
 function (tt::Cyclotomic)
-	s4,e1=nesum(tt, k3, 0, q-2, congruence)
+	s4=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s4, [k1,k2], [1//2*q-1//2,1//2*q-1//2])
 	s2=eesubs(s4, [k1], [k2])
 	s3=eesubs(s4, [k1], [-k2])
-	s4,e2=nesum(s4, k1, 1, q-2, congruence)
+	s4=nesum(s4, k1, 1, q-2, congruence)
 	s4=s4-s2-s3
-	s4,e3=nesum(s4, k2, 1, q-2, congruence)
-	(1//8*s4+1//8*s1, union(e1,e2,e3))
+	s4=nesum(s4, k2, 1, q-2, congruence)
+	1//8*s4+1//8*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k3, 0, q-2, congruence)
+	s2=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
+	s2=nesum(s2, k1, 1, q-2, congruence)
 	s1=s2-s1
-	s1,e3=nesum(s1, k2, 1, q, congruence)
-	(1//4*s1, union(e1,e2,e3))
+	s1=nesum(s1, k2, 1, q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k3, 0, q-2, congruence)
+	s2=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q-1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
+	s2=nesum(s2, k1, 1, q-2, congruence)
 	s1=s2-s1
-	s1,e3=nesum(s1, k2, 1, q, congruence)
-	(1//4*s1, union(e1,e2,e3))
+	s1=nesum(s1, k2, 1, q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s4,e1=nesum(tt, k2, 0, q-2, congruence)
+	s4=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s4, [k1], [1//2*q^2-1//2])
 	s2=eesubs(s4, [k1], [k1*(q-1)])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
+	s2=nesum(s2, k1, 1, q, congruence)
 	s3=eesubs(s4, [k1], [k1*(q+1)])
-	s3,e3=nesum(s3, k1, 1, q-2, congruence)
-	s4,e4=nesum(s4, k1, 1, q^2-2, congruence)
-	(1//4*s4-1//4*s2-1//4*s3+1//4*s1, union(e1,e2,e3,e4))
+	s3=nesum(s3, k1, 1, q-2, congruence)
+	s4=nesum(s4, k1, 1, q^2-2, congruence)
+	1//4*s4-1//4*s2-1//4*s3+1//4*s1
 end,
 function (tt::Cyclotomic)
-	s4,e1=nesum(tt, k2, 0, q-2, congruence)
+	s4=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s4, [k1], [1//2*q^2-1//2])
 	s2=eesubs(s4, [k1], [k1*(q-1)])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
+	s2=nesum(s2, k1, 1, q, congruence)
 	s3=eesubs(s4, [k1], [k1*(q+1)])
-	s3,e3=nesum(s3, k1, 1, q-2, congruence)
-	s4,e4=nesum(s4, k1, 1, q^2-2, congruence)
-	(1//4*s4-1//4*s2-1//4*s3+1//4*s1, union(e1,e2,e3,e4))
+	s3=nesum(s3, k1, 1, q-2, congruence)
+	s4=nesum(s4, k1, 1, q^2-2, congruence)
+	1//4*s4-1//4*s2-1//4*s3+1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k3, 0, q-2, congruence)
+	s2=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s2, [k1,k2], [1//2*q-1//2,1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	s2,e3=nesum(s2, k2, 1, q, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2,e3))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	s2=nesum(s2, k2, 1, q, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k3, 0, q-2, congruence)
+	s2=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s2, [k1,k2], [1//2*q-1//2,1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	s2,e3=nesum(s2, k2, 1, q, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2,e3))
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	s2=nesum(s2, k2, 1, q, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k3, 0, q-2, congruence)
+	s2=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
+	s2=nesum(s2, k1, 1, q, congruence)
 	s1=s2-s1
-	s1,e3=nesum(s1, k2, 1, q-2, congruence)
-	(1//4*s1, union(e1,e2,e3))
+	s1=nesum(s1, k2, 1, q-2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k3, 0, q-2, congruence)
+	s2=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q+1//2])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
+	s2=nesum(s2, k1, 1, q, congruence)
 	s1=s2-s1
-	s1,e3=nesum(s1, k2, 1, q-2, congruence)
-	(1//4*s1, union(e1,e2,e3))
+	s1=nesum(s1, k2, 1, q-2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s5,e1=nesum(tt, k3, 0, q-2, congruence)
+	s5=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s5, [k1,k2], [1//2*q+1//2,1//2*q+1//2])
 	s2=eesubs(s5, [k1], [k2])
 	s3=eesubs(s5, [k1], [-k2])
 	s4=eesubs(s5, [k1], [1//2*q+1//2])
-	s5,e2=nesum(s5, k1, 1, q, congruence)
+	s5=nesum(s5, k1, 1, q, congruence)
 	s5=s5-s2-s3-s4
-	s5,e3=nesum(s5, k2, 1, q, congruence)
-	(1//4*s5+1//2*s1, union(e1,e2,e3))
+	s5=nesum(s5, k2, 1, q, congruence)
+	1//4*s5+1//2*s1
 end,
 function (tt::Cyclotomic)
-	s5,e1=nesum(tt, k3, 0, q-2, congruence)
+	s5=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s5, [k1,k2], [1//2*q+1//2,1//2*q+1//2])
 	s2=eesubs(s5, [k1], [k2])
 	s3=eesubs(s5, [k1], [-k2])
 	s4=eesubs(s5, [k1], [1//2*q+1//2])
-	s5,e2=nesum(s5, k1, 1, q, congruence)
+	s5=nesum(s5, k1, 1, q, congruence)
 	s5=s5-s2-s3-s4
-	s5,e3=nesum(s5, k2, 1, q, congruence)
-	(1//4*s5+1//2*s1, union(e1,e2,e3))
+	s5=nesum(s5, k2, 1, q, congruence)
+	1//4*s5+1//2*s1
 end,
 function (tt::Cyclotomic)
-	s4,e1=nesum(tt, k3, 0, q-2, congruence)
+	s4=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s4, [k1,k2], [1//2*q+1//2,1//2*q+1//2])
 	s2=eesubs(s4, [k1], [k2])
 	s3=eesubs(s4, [k1], [-k2])
-	s4,e2=nesum(s4, k1, 1, q, congruence)
+	s4=nesum(s4, k1, 1, q, congruence)
 	s4=s4-s2-s3
-	s4,e3=nesum(s4, k2, 1, q, congruence)
-	(1//8*s4+1//8*s1, union(e1,e2,e3))
+	s4=nesum(s4, k2, 1, q, congruence)
+	1//8*s4+1//8*s1
 end,
 function (tt::Cyclotomic)
-	s4,e1=nesum(tt, k3, 0, q-2, congruence)
+	s4=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s4, [k1,k2], [1//2*q+1//2,1//2*q+1//2])
 	s2=eesubs(s4, [k1], [k2])
 	s3=eesubs(s4, [k1], [-k2])
-	s4,e2=nesum(s4, k1, 1, q, congruence)
+	s4=nesum(s4, k1, 1, q, congruence)
 	s4=s4-s2-s3
-	s4,e3=nesum(s4, k2, 1, q, congruence)
-	(1//8*s4+1//8*s1, union(e1,e2,e3))
+	s4=nesum(s4, k2, 1, q, congruence)
+	1//8*s4+1//8*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q^2+1//2])
-	s2,e2=nesum(s2, k1, 1, q^2, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q^2, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q^2+1//2])
-	s2,e2=nesum(s2, k1, 1, q^2, congruence)
-	(1//4*s2-1//4*s1, union(e1,e2))
+	s2=nesum(s2, k1, 1, q^2, congruence)
+	1//4*s2-1//4*s1
 end,
 function (tt::Cyclotomic)
-	s7,e1=nesum(tt, k4, 0, q-2, congruence)
+	s7=nesum(tt, k4, 0, q-2, congruence)
 	s1=eesubs(s7, [k1,k2], [1//2*q-1//2,1//2*q-1//2])
 	s2=eesubs(s7, [k1], [k2])
 	s3=eesubs(s7, [k1], [-k2])
 	s4=eesubs(s7, [k1], [k3])
 	s5=eesubs(s7, [k1], [-k3])
-	s6,e2=nesum(s7, k1, 1, q-2, congruence)
+	s6=nesum(s7, k1, 1, q-2, congruence)
 	s6=s6-s5-s4-s3-s2
 	s2=eesubs(s6, [k2], [k3])
 	s3=eesubs(s6, [k2], [-k3])
-	s6,e3=nesum(s6, k2, 1, q-2, congruence)
+	s6=nesum(s6, k2, 1, q-2, congruence)
 	s6=s6-s2-s3+s1
 	s2=eesubs(s6, [k3], [1//2*q-1//2])
-	s6,e4=nesum(s6, k3, 1, q-2, congruence)
+	s6=nesum(s6, k3, 1, q-2, congruence)
 	zw1=s6-s2
 	s1=eesubs(s7, [k1], [k2])
 	s2=eesubs(s7, [k1], [-k2])
 	s3=eesubs(s7, [k1], [1//2*q-1//2])
-	s4,e5=nesum(s7, k1, 1, q-2, congruence)
+	s4=nesum(s7, k1, 1, q-2, congruence)
 	s4=s4-s3-s2-s1
 	s1=eesubs(s4, [k2], [1//2*q-1//2])
-	s4,e6=nesum(s4, k2, 1, q-2, congruence)
+	s4=nesum(s4, k2, 1, q-2, congruence)
 	s4=s4-s1
 	zw2=eesubs(s4, [k3], [1//2*q-1//2])
-	(1//48*zw1+1//48*zw2, union(e1,e2,e3,e4,e5,e6))
+	1//48*zw1+1//48*zw2
 end,
 function (tt::Cyclotomic)
-	s5,e1=nesum(tt, k4, 0, q-2, congruence)
+	s5=nesum(tt, k4, 0, q-2, congruence)
 	s1=eesubs(s5, [k1,k2], [1//2*q-1//2,1//2*q-1//2])
 	s2=eesubs(s5, [k1], [k2])
 	s3=eesubs(s5, [k1], [-k2])
-	s4,e2=nesum(s5, k1, 1, q-2, congruence)
+	s4=nesum(s5, k1, 1, q-2, congruence)
 	s4=s4-s3-s2
-	s4,e3=nesum(s4, k2, 1, q-2, congruence)
+	s4=nesum(s4, k2, 1, q-2, congruence)
 	s4=s4+s1
 	s2=eesubs(s4, [k3], [1//2*q+1//2])
-	s4,e4=nesum(s4, k3, 1, q, congruence)
+	s4=nesum(s4, k3, 1, q, congruence)
 	zw1=s4-s2
 	s1=eesubs(s5, [k1], [k2])
 	s2=eesubs(s5, [k1], [-k2])
 	s3=eesubs(s5, [k1], [1//2*q-1//2])
-	s4,e5=nesum(s5, k1, 1, q-2, congruence)
+	s4=nesum(s5, k1, 1, q-2, congruence)
 	s4=s4-s3-s2-s1
 	s1=eesubs(s4, [k2], [1//2*q-1//2])
-	s4,e6=nesum(s4, k2, 1, q-2, congruence)
+	s4=nesum(s4, k2, 1, q-2, congruence)
 	s4=s4-s1
 	zw2=eesubs(s4, [k3], [1//2*q+1//2])
-	(1//16*zw1+1//16*zw2, union(e1,e2,e3,e4,e5,e6))
+	1//16*zw1+1//16*zw2
 end,
 function (tt::Cyclotomic)
-	s4,e1=nesum(tt, k3, 0, q-2, congruence)
+	s4=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s4, [k1], [1//2*q^2-1//2])
 	s2=eesubs(s4, [k1], [k1*(q-1)])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
+	s2=nesum(s2, k1, 1, q, congruence)
 	s3=eesubs(s4, [k1], [k1*(q+1)])
-	s3,e3=nesum(s3, k1, 1, q-2, congruence)
-	s4,e4=nesum(s4, k1, 1, q^2-2, congruence)
+	s3=nesum(s3, k1, 1, q-2, congruence)
+	s4=nesum(s4, k1, 1, q^2-2, congruence)
 	s4=s4-s2-s3+s1
-	s4,e5=nesum(s4, k2, 1, q-2, congruence)
-	(1//8*s4, union(e1,e2,e3,e4,e5))
+	s4=nesum(s4, k2, 1, q-2, congruence)
+	1//8*s4
 end,
 function (tt::Cyclotomic)
-	s5,e1=nesum(tt, k4, 0, q-2, congruence)
+	s5=nesum(tt, k4, 0, q-2, congruence)
 	s1=eesubs(s5, [k1,k2], [1//2*q-1//2,1//2*q+1//2])
-	s2,e2=nesum(s5, k1, 1, q-2, congruence)
+	s2=nesum(s5, k1, 1, q-2, congruence)
 	s3=eesubs(s2, [k2], [k3])
 	s4=eesubs(s2, [k2], [-k3])
-	s2,e3=nesum(s2, k2, 1, q, congruence)
+	s2=nesum(s2, k2, 1, q, congruence)
 	s2=s2-s3-s4-s1
 	s3=eesubs(s2, [k3], [1//2*q+1//2])
-	s2,e4=nesum(s2, k3, 1, q, congruence)
+	s2=nesum(s2, k3, 1, q, congruence)
 	zw1=s2-s3
 	s1=eesubs(s5, [k1], [1//2*q-1//2])
-	s2,e5=nesum(s5, k1, 1, q-2, congruence)
+	s2=nesum(s5, k1, 1, q-2, congruence)
 	s1=s2-s1
 	s2=eesubs(s1, [k2], [1//2*q+1//2])
-	s1,e6=nesum(s1, k2, 1, q, congruence)
+	s1=nesum(s1, k2, 1, q, congruence)
 	s1=s1-s2
 	zw2=eesubs(s1, [k3], [1//2*q+1//2])
-	(1//16*zw1+1//16*zw2, union(e1,e2,e3,e4,e5,e6))
+	1//16*zw1+1//16*zw2
 end,
 function (tt::Cyclotomic)
-	s4,e1=nesum(tt, k3, 0, q-2, congruence)
+	s4=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s4, [k1], [1//2*q^2-1//2])
 	s2=eesubs(s4, [k1], [k1*(q-1)])
-	s2,e2=nesum(s2, k1, 1, q, congruence)
+	s2=nesum(s2, k1, 1, q, congruence)
 	s3=eesubs(s4, [k1], [k1*(q+1)])
-	s3,e3=nesum(s3, k1, 1, q-2, congruence)
-	s4,e4=nesum(s4, k1, 1, q^2-2, congruence)
+	s3=nesum(s3, k1, 1, q-2, congruence)
+	s4=nesum(s4, k1, 1, q^2-2, congruence)
 	s4=s4-s2-s3+s1
-	s4,e5=nesum(s4, k2, 1, q, congruence)
-	(1//8*s4, union(e1,e2,e3,e4,e5))
+	s4=nesum(s4, k2, 1, q, congruence)
+	1//8*s4
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k3, 0, q-2, congruence)
-	s1,e2=nesum(s2, k1, 1, q-2, congruence)
+	s2=nesum(tt, k3, 0, q-2, congruence)
+	s1=nesum(s2, k1, 1, q-2, congruence)
 	s2=eesubs(s1, [k2], [1//2*q^2+1//2])
-	s1,e3=nesum(s1, k2, 1, q^2, congruence)
-	(1//8*s1-1//8*s2, union(e1,e2,e3))
+	s1=nesum(s1, k2, 1, q^2, congruence)
+	1//8*s1-1//8*s2
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [(q^2+q+1)*k1])
-	s1,e2=nesum(s1, k1, 0, q-2, congruence)
-	s2,e3=nesum(s2, k1, 0, q^3-2, congruence)
-	(1//6*s2-1//6*s1, union(e1,e2,e3))
+	s1=nesum(s1, k1, 0, q-2, congruence)
+	s2=nesum(s2, k1, 0, q^3-2, congruence)
+	1//6*s2-1//6*s1
 end,
 function (tt::Cyclotomic)
-	s7,e1=nesum(tt, k4, 0, q-2, congruence)
+	s7=nesum(tt, k4, 0, q-2, congruence)
 	s1=eesubs(s7, [k1,k2], [1//2*q+1//2,1//2*q+1//2])
 	s2=eesubs(s7, [k1], [k2])
 	s3=eesubs(s7, [k1], [-k2])
 	s4=eesubs(s7, [k1], [k3])
 	s5=eesubs(s7, [k1], [-k3])
-	s6,e2=nesum(s7, k1, 1, q, congruence)
+	s6=nesum(s7, k1, 1, q, congruence)
 	s6=s6-s5-s4-s3-s2
 	s2=eesubs(s6, [k2], [k3])
 	s3=eesubs(s6, [k2], [-k3])
-	s6,e3=nesum(s6, k2, 1, q, congruence)
+	s6=nesum(s6, k2, 1, q, congruence)
 	s6=s6-s2-s3+s1
 	s2=eesubs(s6, [k3], [1//2*q+1//2])
-	s6,e4=nesum(s6, k3, 1, q, congruence)
+	s6=nesum(s6, k3, 1, q, congruence)
 	zw1=s6-s2
 	s1=eesubs(s7, [k1], [k2])
 	s2=eesubs(s7, [k1], [-k2])
 	s3=eesubs(s7, [k1], [1//2*q+1//2])
-	s4,e5=nesum(s7, k1, 1, q, congruence)
+	s4=nesum(s7, k1, 1, q, congruence)
 	s4=s4-s3-s2-s1
 	s1=eesubs(s4, [k2], [1//2*q+1//2])
-	s4,e6=nesum(s4, k2, 1, q, congruence)
+	s4=nesum(s4, k2, 1, q, congruence)
 	s4=s4-s1
 	zw2=eesubs(s4, [k3], [1//2*q+1//2])
-	(1//48*zw1+1//48*zw2, union(e1,e2,e3,e4,e5,e6))
+	1//48*zw1+1//48*zw2
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k3, 0, q-2, congruence)
+	s2=nesum(tt, k3, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [1//2*q^2+1//2])
-	s2,e2=nesum(s2, k1, 1, q^2, congruence)
+	s2=nesum(s2, k1, 1, q^2, congruence)
 	s2=s2-s1
-	s2,e3=nesum(s2, k2, 1, q, congruence)
-	(1//8*s2, union(e1,e2,e3))
+	s2=nesum(s2, k2, 1, q, congruence)
+	1//8*s2
 end,
 function (tt::Cyclotomic)
-	s2,e1=nesum(tt, k2, 0, q-2, congruence)
+	s2=nesum(tt, k2, 0, q-2, congruence)
 	s1=eesubs(s2, [k1], [(q^2-q+1)*k1])
-	s1,e2=nesum(s1, k1, 0, q, congruence)
-	s2,e3=nesum(s2, k1, 0, q^3, congruence)
-	(1//6*s2-1//6*s1, union(e1,e2,e3))
+	s1=nesum(s1, k1, 0, q, congruence)
+	s2=nesum(s2, k1, 0, q^3, congruence)
+	1//6*s2-1//6*s1
 end
 ]
 

--- a/src/Tables/C3/Sp6.0.jl
+++ b/src/Tables/C3/Sp6.0.jl
@@ -4635,705 +4635,705 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	(1//2*zw1, e1)
-end,
-function (tt::Cyclotomic)
-	s1=eesubs(tt, [i1], [i2])
-	s2=eesubs(tt, [i1], [-i2])
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 1, q-2, congruence)
-	(1//8*zw1, union(e1,e2))
+	zw1=nesum(tt, i1, 1, q, congruence)
+	1//2*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [-i2])
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 1, q-2, congruence)
-	(1//8*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 1, q-2, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [-i2])
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 1, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 1, q-2, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [-i2])
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 1, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 1, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
-	(1//4*zw1, union(e1,e2))
+	s1=eesubs(tt, [i1], [i2])
+	s2=eesubs(tt, [i1], [-i2])
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=zw1-s1-s2
+	zw1=nesum(zw1, i2, 1, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=nesum(zw1, i2, 1, q, congruence)
+	1//4*zw1
+end,
+function (tt::Cyclotomic)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=nesum(zw1, i2, 1, q, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q+1)])
 	s2=eesubs(tt, [i1], [i1*(q-1)])
-	s1,e1=nesum(s1, i1, 1, q-2, congruence)
-	s2,e2=nesum(s2, i1, 1, q, congruence)
-	zw1,e3=nesum(tt, i1, 1, q^2-2, congruence)
+	s1=nesum(s1, i1, 1, q-2, congruence)
+	s2=nesum(s2, i1, 1, q, congruence)
+	zw1=nesum(tt, i1, 1, q^2-2, congruence)
 	zw1=zw1-s1-s2
-	(1//4*zw1, union(e1,e2,e3))
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q+1)])
 	s2=eesubs(tt, [i1], [i1*(q-1)])
-	s1,e1=nesum(s1, i1, 1, q-2, congruence)
-	s2,e2=nesum(s2, i1, 1, q, congruence)
-	zw1,e3=nesum(tt, i1, 1, q^2-2, congruence)
+	s1=nesum(s1, i1, 1, q-2, congruence)
+	s2=nesum(s2, i1, 1, q, congruence)
+	zw1=nesum(tt, i1, 1, q^2-2, congruence)
 	zw1=zw1-s1-s2
-	(1//4*zw1, union(e1,e2,e3))
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=nesum(zw1, i2, 1, q, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=nesum(zw1, i2, 1, q, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	zw1,e2=nesum(zw1, i2, 1, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i1, 1, q, congruence)
+	zw1=nesum(zw1, i2, 1, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
-	zw1,e2=nesum(zw1, i2, 1, q-2, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(tt, i1, 1, q, congruence)
+	zw1=nesum(zw1, i2, 1, q-2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [-i2])
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
+	zw1=nesum(tt, i1, 1, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
-	(1//8*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 1, q, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [-i2])
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
+	zw1=nesum(tt, i1, 1, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
-	(1//8*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 1, q, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q^2, congruence)
-	(1//4*zw1, e1)
+	zw1=nesum(tt, i1, 1, q^2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q^2, congruence)
-	(1//4*zw1, e1)
+	zw1=nesum(tt, i1, 1, q^2, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [-i2])
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
+	zw1=nesum(tt, i1, 1, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 1, q, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [-i2])
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
+	zw1=nesum(tt, i1, 1, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
-	(1//4*zw1, union(e1,e2))
+	zw1=nesum(zw1, i2, 1, q, congruence)
+	1//4*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i3], [i1])
 	s2=eesubs(tt, [i3], [-i1])
 	s3=eesubs(tt, [i3], [i2])
 	s4=eesubs(tt, [i3], [-i2])
-	zw1,e1=nesum(tt, i3, 1, q-2, congruence)
+	zw1=nesum(tt, i3, 1, q-2, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [i1])
 	s2=eesubs(zw1, [i2], [-i1])
-	zw1,e2=nesum(zw1, i2, 1, q-2, congruence)
+	zw1=nesum(zw1, i2, 1, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e3=nesum(zw1, i1, 1, q-2, congruence)
-	(1//48*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i1, 1, q-2, congruence)
+	1//48*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i2])
 	s2=eesubs(tt, [i1], [-i2])
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e2=nesum(zw1, i2, 1, q-2, congruence)
-	zw1,e3=nesum(zw1, i3, 1, q, congruence)
-	(1//16*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i2, 1, q-2, congruence)
+	zw1=nesum(zw1, i3, 1, q, congruence)
+	1//16*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q+1)])
 	s2=eesubs(tt, [i1], [i1*(q-1)])
-	s1,e1=nesum(s1, i1, 1, q-2, congruence)
-	s2,e2=nesum(s2, i1, 1, q, congruence)
-	zw1,e3=nesum(tt, i1, 1, q^2-2, congruence)
+	s1=nesum(s1, i1, 1, q-2, congruence)
+	s2=nesum(s2, i1, 1, q, congruence)
+	zw1=nesum(tt, i1, 1, q^2-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e4=nesum(zw1, i2, 1, q-2, congruence)
-	(1//8*zw1, union(e1,e2,e3,e4))
+	zw1=nesum(zw1, i2, 1, q-2, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=nesum(tt, i1, 1, q-2, congruence)
 	s1=eesubs(zw1, [i2], [i3])
 	s2=eesubs(zw1, [i2], [-i3])
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
+	zw1=nesum(zw1, i2, 1, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e3=nesum(zw1, i3, 1, q, congruence)
-	(1//16*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i3, 1, q, congruence)
+	1//16*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q+1)])
 	s2=eesubs(tt, [i1], [i1*(q-1)])
-	s1,e1=nesum(s1, i1, 1, q-2, congruence)
-	s2,e2=nesum(s2, i1, 1, q, congruence)
-	zw1,e3=nesum(tt, i1, 1, q^2-2, congruence)
+	s1=nesum(s1, i1, 1, q-2, congruence)
+	s2=nesum(s2, i1, 1, q, congruence)
+	zw1=nesum(tt, i1, 1, q^2-2, congruence)
 	zw1=zw1-s1-s2
-	zw1,e4=nesum(zw1, i2, 1, q, congruence)
-	(1//8*zw1, union(e1,e2,e3,e4))
+	zw1=nesum(zw1, i2, 1, q, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q-2, congruence)
-	zw1,e2=nesum(zw1, i2, 1, q^2, congruence)
-	(1//8*zw1, union(e1,e2))
+	zw1=nesum(tt, i1, 1, q-2, congruence)
+	zw1=nesum(zw1, i2, 1, q^2, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q^2+q+1)])
-	s1,e1=nesum(s1, i1, 0, q-2, congruence)
-	zw1,e2=nesum(tt, i1, 0, q^3-2, congruence)
-	(1//6*zw1-1//6*s1, union(e1,e2))
+	s1=nesum(s1, i1, 0, q-2, congruence)
+	zw1=nesum(tt, i1, 0, q^3-2, congruence)
+	1//6*zw1-1//6*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i3])
 	s2=eesubs(tt, [i1], [-i3])
 	s3=eesubs(tt, [i1], [i2])
 	s4=eesubs(tt, [i1], [-i2])
-	zw1,e1=nesum(tt, i1, 1, q, congruence)
+	zw1=nesum(tt, i1, 1, q, congruence)
 	zw1=zw1-s1-s2-s3-s4
 	s1=eesubs(zw1, [i2], [i3])
 	s2=eesubs(zw1, [i2], [-i3])
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
+	zw1=nesum(zw1, i2, 1, q, congruence)
 	zw1=zw1-s1-s2
-	zw1,e3=nesum(zw1, i3, 1, q, congruence)
-	(1//48*zw1, union(e1,e2,e3))
+	zw1=nesum(zw1, i3, 1, q, congruence)
+	1//48*zw1
 end,
 function (tt::Cyclotomic)
-	zw1,e1=nesum(tt, i1, 1, q^2, congruence)
-	zw1,e2=nesum(zw1, i2, 1, q, congruence)
-	(1//8*zw1, union(e1,e2))
+	zw1=nesum(tt, i1, 1, q^2, congruence)
+	zw1=nesum(zw1, i2, 1, q, congruence)
+	1//8*zw1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [i1], [i1*(q^2-q+1)])
-	s1,e1=nesum(s1, i1, 0, q, congruence)
-	zw1,e2=nesum(tt, i1, 0, q^3, congruence)
-	(1//6*zw1-1//6*s1, union(e1,e2))
+	s1=nesum(s1, i1, 0, q, congruence)
+	zw1=nesum(tt, i1, 0, q^3, congruence)
+	1//6*zw1-1//6*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	(1//2*s1, e1)
-end,
-function (tt::Cyclotomic)
-	s1=eesubs(tt, [k1], [k2])
-	s2=eesubs(tt, [k1], [-k2])
-	s3,e1=nesum(tt, k1, 1, q-2, congruence)
-	s3=s3-s2-s1
-	s3,e2=nesum(s3, k2, 1, q-2, congruence)
-	(1//4*s3, union(e1,e2))
+	s1=nesum(tt, k1, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k2])
 	s2=eesubs(tt, [k1], [-k2])
-	s3,e1=nesum(tt, k1, 1, q-2, congruence)
+	s3=nesum(tt, k1, 1, q-2, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, k2, 1, q-2, congruence)
-	(1//4*s3, union(e1,e2))
+	s3=nesum(s3, k2, 1, q-2, congruence)
+	1//4*s3
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k2])
 	s2=eesubs(tt, [k1], [-k2])
-	s3,e1=nesum(tt, k1, 1, q-2, congruence)
+	s3=nesum(tt, k1, 1, q-2, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, k2, 1, q-2, congruence)
-	(1//8*s3, union(e1,e2))
+	s3=nesum(s3, k2, 1, q-2, congruence)
+	1//4*s3
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k2])
 	s2=eesubs(tt, [k1], [-k2])
-	s3,e1=nesum(tt, k1, 1, q-2, congruence)
+	s3=nesum(tt, k1, 1, q-2, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, k2, 1, q-2, congruence)
-	(1//8*s3, union(e1,e2))
+	s3=nesum(s3, k2, 1, q-2, congruence)
+	1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 1, q, congruence)
-	(1//4*s1, union(e1,e2))
+	s1=eesubs(tt, [k1], [k2])
+	s2=eesubs(tt, [k1], [-k2])
+	s3=nesum(tt, k1, 1, q-2, congruence)
+	s3=s3-s2-s1
+	s3=nesum(s3, k2, 1, q-2, congruence)
+	1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 1, q, congruence)
-	(1//4*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 1, q, congruence)
+	1//4*s1
+end,
+function (tt::Cyclotomic)
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 1, q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k1*(q-1)])
-	s1,e1=nesum(s1, k1, 1, q, congruence)
+	s1=nesum(s1, k1, 1, q, congruence)
 	s2=eesubs(tt, [k1], [k1*(q+1)])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	s3,e3=nesum(tt, k1, 1, q^2-2, congruence)
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	s3=nesum(tt, k1, 1, q^2-2, congruence)
 	s3=s3-s2-s1
-	(1//4*s3, union(e1,e2,e3))
+	1//4*s3
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k1*(q-1)])
-	s1,e1=nesum(s1, k1, 1, q, congruence)
+	s1=nesum(s1, k1, 1, q, congruence)
 	s2=eesubs(tt, [k1], [k1*(q+1)])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	s3,e3=nesum(tt, k1, 1, q^2-2, congruence)
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	s3=nesum(tt, k1, 1, q^2-2, congruence)
 	s3=s3-s2-s1
-	(1//4*s3, union(e1,e2,e3))
+	1//4*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 1, q, congruence)
-	(1//4*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 1, q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 1, q, congruence)
-	(1//4*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 1, q, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	s1,e2=nesum(s1, k2, 1, q-2, congruence)
-	(1//4*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q, congruence)
+	s1=nesum(s1, k2, 1, q-2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q, congruence)
-	s1,e2=nesum(s1, k2, 1, q-2, congruence)
-	(1//4*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q, congruence)
+	s1=nesum(s1, k2, 1, q-2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k2])
 	s2=eesubs(tt, [k1], [-k2])
-	s3,e1=nesum(tt, k1, 1, q, congruence)
+	s3=nesum(tt, k1, 1, q, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, k2, 1, q, congruence)
-	(1//4*s3, union(e1,e2))
+	s3=nesum(s3, k2, 1, q, congruence)
+	1//4*s3
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k2])
 	s2=eesubs(tt, [k1], [-k2])
-	s3,e1=nesum(tt, k1, 1, q, congruence)
+	s3=nesum(tt, k1, 1, q, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, k2, 1, q, congruence)
-	(1//4*s3, union(e1,e2))
+	s3=nesum(s3, k2, 1, q, congruence)
+	1//4*s3
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k2])
 	s2=eesubs(tt, [k1], [-k2])
-	s3,e1=nesum(tt, k1, 1, q, congruence)
+	s3=nesum(tt, k1, 1, q, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, k2, 1, q, congruence)
-	(1//8*s3, union(e1,e2))
+	s3=nesum(s3, k2, 1, q, congruence)
+	1//8*s3
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k2])
 	s2=eesubs(tt, [k1], [-k2])
-	s3,e1=nesum(tt, k1, 1, q, congruence)
+	s3=nesum(tt, k1, 1, q, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, k2, 1, q, congruence)
-	(1//8*s3, union(e1,e2))
+	s3=nesum(s3, k2, 1, q, congruence)
+	1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q^2, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, k1, 1, q^2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q^2, congruence)
-	(1//4*s1, e1)
+	s1=nesum(tt, k1, 1, q^2, congruence)
+	1//4*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k2])
 	s2=eesubs(tt, [k1], [-k2])
 	s3=eesubs(tt, [k1], [k3])
 	s4=eesubs(tt, [k1], [-k3])
-	s5,e1=nesum(tt, k1, 1, q-2, congruence)
+	s5=nesum(tt, k1, 1, q-2, congruence)
 	s5=s5-s4-s3-s2-s1
 	s1=eesubs(s5, [k2], [k3])
 	s2=eesubs(s5, [k2], [-k3])
-	s3,e2=nesum(s5, k2, 1, q-2, congruence)
+	s3=nesum(s5, k2, 1, q-2, congruence)
 	s3=s3-s2-s1
-	s3,e3=nesum(s3, k3, 1, q-2, congruence)
-	(1//48*s3, union(e1,e2,e3))
+	s3=nesum(s3, k3, 1, q-2, congruence)
+	1//48*s3
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k2])
 	s2=eesubs(tt, [k1], [-k2])
-	s3,e1=nesum(tt, k1, 1, q-2, congruence)
+	s3=nesum(tt, k1, 1, q-2, congruence)
 	s3=s3-s2-s1
-	s3,e2=nesum(s3, k2, 1, q-2, congruence)
-	s3,e3=nesum(s3, k3, 1, q, congruence)
-	(1//16*s3, union(e1,e2,e3))
+	s3=nesum(s3, k2, 1, q-2, congruence)
+	s3=nesum(s3, k3, 1, q, congruence)
+	1//16*s3
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k1*(q-1)])
-	s1,e1=nesum(s1, k1, 1, q, congruence)
+	s1=nesum(s1, k1, 1, q, congruence)
 	s2=eesubs(tt, [k1], [k1*(q+1)])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	s3,e3=nesum(tt, k1, 1, q^2-2, congruence)
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	s3=nesum(tt, k1, 1, q^2-2, congruence)
 	s3=s3-s2-s1
-	s3,e4=nesum(s3, k2, 1, q-2, congruence)
-	(1//8*s3, union(e1,e2,e3,e4))
+	s3=nesum(s3, k2, 1, q-2, congruence)
+	1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(tt, k1, 1, q-2, congruence)
 	s2=eesubs(s1, [k2], [k3])
 	s3=eesubs(s1, [k2], [-k3])
-	s1,e2=nesum(s1, k2, 1, q, congruence)
+	s1=nesum(s1, k2, 1, q, congruence)
 	s1=s1-s3-s2
-	s1,e3=nesum(s1, k3, 1, q, congruence)
-	(1//16*s1, union(e1,e2,e3))
+	s1=nesum(s1, k3, 1, q, congruence)
+	1//16*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k1*(q-1)])
-	s1,e1=nesum(s1, k1, 1, q, congruence)
+	s1=nesum(s1, k1, 1, q, congruence)
 	s2=eesubs(tt, [k1], [k1*(q+1)])
-	s2,e2=nesum(s2, k1, 1, q-2, congruence)
-	s3,e3=nesum(tt, k1, 1, q^2-2, congruence)
+	s2=nesum(s2, k1, 1, q-2, congruence)
+	s3=nesum(tt, k1, 1, q^2-2, congruence)
 	s3=s3-s2-s1
-	s3,e4=nesum(s3, k2, 1, q, congruence)
-	(1//8*s3, union(e1,e2,e3,e4))
+	s3=nesum(s3, k2, 1, q, congruence)
+	1//8*s3
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q-2, congruence)
-	s1,e2=nesum(s1, k2, 1, q^2, congruence)
-	(1//8*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q-2, congruence)
+	s1=nesum(s1, k2, 1, q^2, congruence)
+	1//8*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [(q^2+q+1)*k1])
-	s1,e1=nesum(s1, k1, 0, q-2, congruence)
-	s2,e2=nesum(tt, k1, 0, q^3-2, congruence)
+	s1=nesum(s1, k1, 0, q-2, congruence)
+	s2=nesum(tt, k1, 0, q^3-2, congruence)
 	s2=s2-s1
-	(1//6*s2, union(e1,e2))
+	1//6*s2
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [k2])
 	s2=eesubs(tt, [k1], [-k2])
 	s3=eesubs(tt, [k1], [k3])
 	s4=eesubs(tt, [k1], [-k3])
-	s5,e1=nesum(tt, k1, 1, q, congruence)
+	s5=nesum(tt, k1, 1, q, congruence)
 	s5=s5-s4-s3-s2-s1
 	s1=eesubs(s5, [k2], [k3])
 	s2=eesubs(s5, [k2], [-k3])
-	s5,e2=nesum(s5, k2, 1, q, congruence)
+	s5=nesum(s5, k2, 1, q, congruence)
 	s5=s5-s2-s1
-	s5,e3=nesum(s5, k3, 1, q, congruence)
-	(1//48*s5, union(e1,e2,e3))
+	s5=nesum(s5, k3, 1, q, congruence)
+	1//48*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k1, 1, q^2, congruence)
-	s1,e2=nesum(s1, k2, 1, q, congruence)
-	(1//8*s1, union(e1,e2))
+	s1=nesum(tt, k1, 1, q^2, congruence)
+	s1=nesum(s1, k2, 1, q, congruence)
+	1//8*s1
 end,
 function (tt::Cyclotomic)
 	s1=eesubs(tt, [k1], [(q^2-q+1)*k1])
-	s1,e1=nesum(s1, k1, 0, q, congruence)
-	s2,e2=nesum(tt, k1, 0, q^3, congruence)
+	s1=nesum(s1, k1, 0, q, congruence)
+	s2=nesum(tt, k1, 0, q^3, congruence)
 	s2=s2-s1
-	(1//6*s2, union(e1,e2))
+	1//6*s2
 end
 ]
 

--- a/src/Tables/F4/uniuniF4p2.jl
+++ b/src/Tables/F4/uniuniF4p2.jl
@@ -1453,223 +1453,223 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end
 ]
 

--- a/src/Tables/G2/G2.01.jl
+++ b/src/Tables/G2/G2.01.jl
@@ -852,250 +852,250 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//3])
-	(1//2*s1-tt1, e1)
+	1//2*s1-tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//3])
-	(1//2*s1-tt1, e1)
+	1//2*s1-tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	s2,e2=nesum(s1, j, 1, q-2, congruence)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	s2=nesum(s1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q-2, congruence)
+	s3=nesum(tt1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q-2, congruence)
+	s4=nesum(tt1, i, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q-2, congruence)
+	s5=nesum(tt1, j, 1, q-2, congruence)
 	s7=eesubs(tt, [j,i], S.([i,(q-1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//3*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//3*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [j], [i])
 	tt2=eesubs(tt, [j], [-i])
 	tt3=eesubs(tt, [j], [-2*i])
-	s1,e1=nesum(tt, j, 1, q, congruence)
+	s1=nesum(tt, j, 1, q, congruence)
 	s2=s1-tt1-tt2-2*tt3
-	s1,e2=nesum(s2, i, 1, q, congruence)
-	(1//12*s1, union(e1,e2))
+	s1=nesum(s2, i, 1, q, congruence)
+	1//12*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2+q, congruence)
+	s1=nesum(tt, i, 1, q^2+q, congruence)
 	s2=eesubs(tt, [i], [(q^2+q+1)*1//3])
-	(1//6*s1-1//3*s2, e1)
+	1//6*s1-1//3*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2-q, congruence)
+	1//6*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//3])
-	(1//2*s1-tt1, e1)
+	1//2*s1-tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//3])
-	(1//2*s1-tt1, e1)
+	1//2*s1-tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	s2,e2=nesum(s1, l, 1, q-2, congruence)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	s2=nesum(s1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q-2, congruence)
+	s3=nesum(tt1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q-2, congruence)
+	s4=nesum(tt1, k, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q-2, congruence)
+	s5=nesum(tt1, l, 1, q-2, congruence)
 	s7=eesubs(tt, [k,l], S.([(q-1)*1//3,2*(q-1)*1//3]))
 	s8=eesubs(tt, [k,l], S.([2*(q-1)*1//3,(q-1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//6*s7+1//6*s8, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//6*s7+1//6*s8
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [l], [k])
 	tt2=eesubs(tt, [l], [-k])
 	tt3=eesubs(tt, [l], [2*k])
-	s1,e1=nesum(tt, l, 1, q, congruence)
+	s1=nesum(tt, l, 1, q, congruence)
 	s2=s1-tt1-tt2-2*tt3
-	s1,e2=nesum(s2, k, 1, q, congruence)
-	(1//12*s1, union(e1,e2))
+	s1=nesum(s2, k, 1, q, congruence)
+	1//12*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
 	s2=eesubs(tt, [k], [(q^2+q+1)*1//3])
-	(1//6*s1-1//3*s2, e1)
+	1//6*s1-1//3*s2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//6*s1
 end
 ]
 

--- a/src/Tables/G2/G2.02.jl
+++ b/src/Tables/G2/G2.02.jl
@@ -852,250 +852,250 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [j], [i])
 	tt2=eesubs(tt, [j], [-i])
 	tt3=eesubs(tt, [j], [-2*i])
-	s1,e1=nesum(tt, j, 1, q-2, congruence)
+	s1=nesum(tt, j, 1, q-2, congruence)
 	s2=s1-tt1-tt2-2*tt3
-	s1,e2=nesum(s2, i, 1, q-2, congruence)
-	(1//12*s1, union(e1,e2))
+	s1=nesum(s2, i, 1, q-2, congruence)
+	1//12*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//3])
-	(1//2*s1-tt1, e1)
+	1//2*s1-tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//3])
-	(1//2*s1-tt1, e1)
+	1//2*s1-tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, i, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	s2,e2=nesum(s1, j, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
+	s2=nesum(s1, j, 1, q, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q, congruence)
+	s3=nesum(tt1, j, 1, q, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q, congruence)
+	s4=nesum(tt1, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q, congruence)
+	s5=nesum(tt1, j, 1, q, congruence)
 	s7=eesubs(tt, [j,i], S.([i,(q+1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//3*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//3*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2+q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2+q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-q, congruence)
+	s1=nesum(tt, i, 1, q^2-q, congruence)
 	s2=eesubs(tt, [i], [(q^2-q+1)*1//3])
-	(1//6*s1-1//3*s2, e1)
+	1//6*s1-1//3*s2
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, (q-2), congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	(1//2*s1, e1)
+	s1=nesum(tt, k, 1, q, congruence)
+	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//3])
-	(1//2*s1-tt1, e1)
+	1//2*s1-tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//3])
-	(1//2*s1-tt1, e1)
+	1//2*s1-tt1
 end,
 function (tt::Cyclotomic)
 	tt1=eesubs(tt, [l], [k])
 	tt2=eesubs(tt, [l], [-k])
 	tt3=eesubs(tt, [l], [2*k])
-	s1,e1=nesum(tt, l, 1, (q-2), congruence)
+	s1=nesum(tt, l, 1, (q-2), congruence)
 	s2=s1-tt1-tt2-2*tt3
-	s1,e2=nesum(s2, k, 1, (q-2), congruence)
-	(1//12*s1, union(e1,e2))
+	s1=nesum(s2, k, 1, (q-2), congruence)
+	1//12*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	s2,e2=nesum(s1, l, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
+	s2=nesum(s1, l, 1, q, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q, congruence)
+	s3=nesum(tt1, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q, congruence)
+	s4=nesum(tt1, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q, congruence)
+	s5=nesum(tt1, l, 1, q, congruence)
 	s7=eesubs(tt, [k,l], S.([2*(q+1)*1//3,(q+1)*1//3]))
 	s8=eesubs(tt, [k,l], S.([(q+1)*1//3,2*(q+1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//6*s7+1//6*s8, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//6*s7+1//6*s8
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
 	s2=eesubs(tt, [k], [(q^2-q+1)*1//3])
-	(1//6*s1-1//3*s2, e1)
+	1//6*s1-1//3*s2
 end
 ]
 

--- a/src/Tables/G2/G2.101.jl
+++ b/src/Tables/G2/G2.101.jl
@@ -911,279 +911,279 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	s2,e2=nesum(s1, j, 1, q-2, congruence)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	s2=nesum(s1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q-2, congruence)
+	s3=nesum(tt1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q-2, congruence)
+	s4=nesum(tt1, i, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q-2, congruence)
+	s5=nesum(tt1, j, 1, q-2, congruence)
 	s6=eesubs(tt, [i,j], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q-1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	s2,e2=nesum(s1, j, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
+	s2=nesum(s1, j, 1, q, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q, congruence)
+	s3=nesum(tt1, j, 1, q, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q, congruence)
+	s4=nesum(tt1, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q, congruence)
+	s5=nesum(tt1, j, 1, q, congruence)
 	s6=eesubs(tt, [i,j], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q+1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2+q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2+q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2-q, congruence)
+	1//6*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	s2,e2=nesum(s1, l, 1, q-2, congruence)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	s2=nesum(s1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q-2, congruence)
+	s3=nesum(tt1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q-2, congruence)
+	s4=nesum(tt1, k, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q-2, congruence)
+	s5=nesum(tt1, l, 1, q-2, congruence)
 	s6=eesubs(tt, [k,l], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q-1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	s2,e2=nesum(s1, l, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
+	s2=nesum(s1, l, 1, q, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q, congruence)
+	s3=nesum(tt1, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q, congruence)
+	s4=nesum(tt1, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q, congruence)
+	s5=nesum(tt1, l, 1, q, congruence)
 	s6=eesubs(tt, [k,l], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q+1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//6*s1
 end
 ]
 

--- a/src/Tables/G2/G2.103.jl
+++ b/src/Tables/G2/G2.103.jl
@@ -911,279 +911,279 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	s2,e2=nesum(s1, j, 1, q-2, congruence)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	s2=nesum(s1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q-2, congruence)
+	s3=nesum(tt1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q-2, congruence)
+	s4=nesum(tt1, i, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q-2, congruence)
+	s5=nesum(tt1, j, 1, q-2, congruence)
 	s6=eesubs(tt, [i,j], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q-1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	s2,e2=nesum(s1, j, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
+	s2=nesum(s1, j, 1, q, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q, congruence)
+	s3=nesum(tt1, j, 1, q, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q, congruence)
+	s4=nesum(tt1, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q, congruence)
+	s5=nesum(tt1, j, 1, q, congruence)
 	s6=eesubs(tt, [i,j], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q+1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2+q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2+q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2-q, congruence)
+	1//6*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	s2,e2=nesum(s1, l, 1, q-2, congruence)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	s2=nesum(s1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q-2, congruence)
+	s3=nesum(tt1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q-2, congruence)
+	s4=nesum(tt1, k, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q-2, congruence)
+	s5=nesum(tt1, l, 1, q-2, congruence)
 	s6=eesubs(tt, [k,l], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q-1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	s2,e2=nesum(s1, l, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
+	s2=nesum(s1, l, 1, q, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q, congruence)
+	s3=nesum(tt1, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q, congruence)
+	s4=nesum(tt1, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q, congruence)
+	s5=nesum(tt1, l, 1, q, congruence)
 	s6=eesubs(tt, [k,l], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q+1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//6*s1
 end
 ]
 

--- a/src/Tables/G2/G2.111.jl
+++ b/src/Tables/G2/G2.111.jl
@@ -1100,307 +1100,307 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
-	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	tt2=eesubs(tt, [i], [(q-1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
-end,
-function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
 	tt2=eesubs(tt, [i], [(q-1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
+	tt1=eesubs(tt, [i], [(q-1)*1//2])
+	tt2=eesubs(tt, [i], [(q-1)*1//3])
+	1//2*s1-1//2*tt1-tt2
+end,
+function (tt::Cyclotomic)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	s2,e2=nesum(s1, j, 1, q-2, congruence)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	s2=nesum(s1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q-2, congruence)
+	s3=nesum(tt1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q-2, congruence)
+	s4=nesum(tt1, i, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q-2, congruence)
+	s5=nesum(tt1, j, 1, q-2, congruence)
 	s6=eesubs(tt, [i,j], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q-1)*1//2,0]))
 	s8=eesubs(tt, [i,j], S.([(q-1)*1//3,(q-1)*1//3]))
 	s9=eesubs(tt, [i,j], S.([2*(q-1)*1//3,2*(q-1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	s2,e2=nesum(s1, j, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
+	s2=nesum(s1, j, 1, q, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q, congruence)
+	s3=nesum(tt1, j, 1, q, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q, congruence)
+	s4=nesum(tt1, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q, congruence)
+	s5=nesum(tt1, j, 1, q, congruence)
 	s6=eesubs(tt, [i,j], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q+1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2+q, congruence)
+	s1=nesum(tt, i, 1, q^2+q, congruence)
 	tt1=eesubs(tt, [i], [(q^2+q+1)*1//3])
-	(1//6*s1-1//3*tt1, e1)
+	1//6*s1-1//3*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2-q, congruence)
+	1//6*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
 	tt2=eesubs(tt, [k], [(q-1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
 	tt2=eesubs(tt, [k], [(q-1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	s2,e2=nesum(s1, l, 1, q-2, congruence)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	s2=nesum(s1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q-2, congruence)
+	s3=nesum(tt1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q-2, congruence)
+	s4=nesum(tt1, k, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q-2, congruence)
+	s5=nesum(tt1, l, 1, q-2, congruence)
 	s6=eesubs(tt, [k,l], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q-1)*1//2,0]))
 	s8=eesubs(tt, [k,l], S.([(q-1)*1//3,2*(q-1)*1//3]))
 	s9=eesubs(tt, [k,l], S.([2*(q-1)*1//3,(q-1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	s2,e2=nesum(s1, l, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
+	s2=nesum(s1, l, 1, q, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q, congruence)
+	s3=nesum(tt1, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q, congruence)
+	s4=nesum(tt1, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q, congruence)
+	s5=nesum(tt1, l, 1, q, congruence)
 	s6=eesubs(tt, [k,l], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q+1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
 	tt1=eesubs(tt, [k], [(q^2+q+1)*1//3])
-	(1//6*s1-1//3*tt1, e1)
+	1//6*s1-1//3*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//6*s1
 end
 ]
 

--- a/src/Tables/G2/G2.113.jl
+++ b/src/Tables/G2/G2.113.jl
@@ -1100,307 +1100,307 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
-	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	tt2=eesubs(tt, [i], [(q-1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
-end,
-function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
 	tt2=eesubs(tt, [i], [(q-1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
+	tt1=eesubs(tt, [i], [(q-1)*1//2])
+	tt2=eesubs(tt, [i], [(q-1)*1//3])
+	1//2*s1-1//2*tt1-tt2
+end,
+function (tt::Cyclotomic)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	s2,e2=nesum(s1, j, 1, q-2, congruence)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	s2=nesum(s1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q-2, congruence)
+	s3=nesum(tt1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q-2, congruence)
+	s4=nesum(tt1, i, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q-2, congruence)
+	s5=nesum(tt1, j, 1, q-2, congruence)
 	s6=eesubs(tt, [i,j], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q-1)*1//2,0]))
 	s8=eesubs(tt, [i,j], S.([(q-1)*1//3,(q-1)*1//3]))
 	s9=eesubs(tt, [i,j], S.([2*(q-1)*1//3,2*(q-1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	s2,e2=nesum(s1, j, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
+	s2=nesum(s1, j, 1, q, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q, congruence)
+	s3=nesum(tt1, j, 1, q, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q, congruence)
+	s4=nesum(tt1, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q, congruence)
+	s5=nesum(tt1, j, 1, q, congruence)
 	s6=eesubs(tt, [i,j], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q+1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2+q, congruence)
+	s1=nesum(tt, i, 1, q^2+q, congruence)
 	tt1=eesubs(tt, [i], [(q^2+q+1)*1//3])
-	(1//6*s1-1//3*tt1, e1)
+	1//6*s1-1//3*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2-q, congruence)
+	1//6*s1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
 	tt2=eesubs(tt, [k], [(q-1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
 	tt2=eesubs(tt, [k], [(q-1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	s2,e2=nesum(s1, l, 1, q-2, congruence)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	s2=nesum(s1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q-2, congruence)
+	s3=nesum(tt1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q-2, congruence)
+	s4=nesum(tt1, k, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q-2, congruence)
+	s5=nesum(tt1, l, 1, q-2, congruence)
 	s6=eesubs(tt, [k,l], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q-1)*1//2,0]))
 	s8=eesubs(tt, [k,l], S.([(q-1)*1//3,2*(q-1)*1//3]))
 	s9=eesubs(tt, [k,l], S.([2*(q-1)*1//3,(q-1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	s2,e2=nesum(s1, l, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
+	s2=nesum(s1, l, 1, q, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q, congruence)
+	s3=nesum(tt1, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q, congruence)
+	s4=nesum(tt1, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q, congruence)
+	s5=nesum(tt1, l, 1, q, congruence)
 	s6=eesubs(tt, [k,l], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q+1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
 	tt1=eesubs(tt, [k], [(q^2+q+1)*1//3])
-	(1//6*s1-1//3*tt1, e1)
+	1//6*s1-1//3*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
+	1//6*s1
 end
 ]
 

--- a/src/Tables/G2/G2.121.jl
+++ b/src/Tables/G2/G2.121.jl
@@ -1100,307 +1100,307 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
 	tt2=eesubs(tt, [i], [(q+1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
 	tt2=eesubs(tt, [i], [(q+1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	s2,e2=nesum(s1, j, 1, q-2, congruence)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	s2=nesum(s1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q-2, congruence)
+	s3=nesum(tt1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q-2, congruence)
+	s4=nesum(tt1, i, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q-2, congruence)
+	s5=nesum(tt1, j, 1, q-2, congruence)
 	s6=eesubs(tt, [i,j], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q-1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	s2,e2=nesum(s1, j, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
+	s2=nesum(s1, j, 1, q, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q, congruence)
+	s3=nesum(tt1, j, 1, q, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q, congruence)
+	s4=nesum(tt1, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q, congruence)
+	s5=nesum(tt1, j, 1, q, congruence)
 	s6=eesubs(tt, [i,j], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q+1)*1//2,0]))
 	s8=eesubs(tt, [i,j], S.([(q+1)*1//3,(q+1)*1//3]))
 	s9=eesubs(tt, [i,j], S.([2*(q+1)*1//3,2*(q+1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2+q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2+q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-q, congruence)
+	s1=nesum(tt, i, 1, q^2-q, congruence)
 	tt1=eesubs(tt, [i], [(q^2-q+1)*1//3])
-	(1//6*s1-1//3*tt1, e1)
+	1//6*s1-1//3*tt1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	tt2=eesubs(tt, [k], [(q+1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
-end,
-function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
 	tt2=eesubs(tt, [k], [(q+1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	s2,e2=nesum(s1, l, 1, q-2, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
+	tt1=eesubs(tt, [k], [(q+1)*1//2])
+	tt2=eesubs(tt, [k], [(q+1)*1//3])
+	1//2*s1-1//2*tt1-tt2
+end,
+function (tt::Cyclotomic)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	s2=nesum(s1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q-2, congruence)
+	s3=nesum(tt1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q-2, congruence)
+	s4=nesum(tt1, k, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q-2, congruence)
+	s5=nesum(tt1, l, 1, q-2, congruence)
 	s6=eesubs(tt, [k,l], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q-1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	s2,e2=nesum(s1, l, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
+	s2=nesum(s1, l, 1, q, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q, congruence)
+	s3=nesum(tt1, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q, congruence)
+	s4=nesum(tt1, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q, congruence)
+	s5=nesum(tt1, l, 1, q, congruence)
 	s6=eesubs(tt, [k,l], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q+1)*1//2,0]))
 	s8=eesubs(tt, [k,l], S.([(q+1)*1//3,2*(q+1)*1//3]))
 	s9=eesubs(tt, [k,l], S.([2*(q+1)*1//3,(q+1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
 	tt1=eesubs(tt, [k], [(q^2-q+1)*1//3])
-	(1//6*s1-1//3*tt1, e1)
+	1//6*s1-1//3*tt1
 end
 ]
 

--- a/src/Tables/G2/G2.123.jl
+++ b/src/Tables/G2/G2.123.jl
@@ -1100,307 +1100,307 @@ chardegree = R.([
 
 classsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, (q-2), congruence)
+	s1=nesum(tt, i, 1, (q-2), congruence)
 	tt1=eesubs(tt, [i], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
 	tt2=eesubs(tt, [i], [(q+1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
 	tt2=eesubs(tt, [i], [(q+1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q-2, congruence)
-	s2,e2=nesum(s1, j, 1, q-2, congruence)
+	s1=nesum(tt, i, 1, q-2, congruence)
+	s2=nesum(s1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q-2, congruence)
+	s3=nesum(tt1, j, 1, q-2, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q-2, congruence)
+	s4=nesum(tt1, i, 1, q-2, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q-2, congruence)
+	s5=nesum(tt1, j, 1, q-2, congruence)
 	s6=eesubs(tt, [i,j], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q-1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q, congruence)
-	s2,e2=nesum(s1, j, 1, q, congruence)
+	s1=nesum(tt, i, 1, q, congruence)
+	s2=nesum(s1, j, 1, q, congruence)
 	tt1=eesubs(tt, [i], [j])
-	s3,e3=nesum(tt1, j, 1, q, congruence)
+	s3=nesum(tt1, j, 1, q, congruence)
 	tt1=eesubs(tt, [j], [-2*i])
-	s4,e4=nesum(tt1, i, 1, q, congruence)
+	s4=nesum(tt1, i, 1, q, congruence)
 	tt1=eesubs(tt, [i], [-j])
-	s5,e5=nesum(tt1, j, 1, q, congruence)
+	s5=nesum(tt1, j, 1, q, congruence)
 	s6=eesubs(tt, [i,j], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [i,j], S.([(q+1)*1//2,0]))
 	s8=eesubs(tt, [i,j], S.([(q+1)*1//3,(q+1)*1//3]))
 	s9=eesubs(tt, [i,j], S.([2*(q+1)*1//3,2*(q+1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-1, congruence)
+	s1=nesum(tt, i, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [i], [(q-1)*i])
-	s2,e2=nesum(tt1, i, 1, q+1, congruence)
+	s2=nesum(tt1, i, 1, q+1, congruence)
 	tt1=eesubs(tt, [i], [(q+1)*i])
-	s3,e3=nesum(tt1, i, 1, q-1, congruence)
+	s3=nesum(tt1, i, 1, q-1, congruence)
 	s4=eesubs(tt, [i], [(q^2-1)*1//2])
 	s5=eesubs(tt, [i], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2+q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, i, 1, q^2+q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, i, 1, q^2-q, congruence)
+	s1=nesum(tt, i, 1, q^2-q, congruence)
 	tt1=eesubs(tt, [i], [(q^2-q+1)*1//3])
-	(1//6*s1-1//3*tt1, e1)
+	1//6*s1-1//3*tt1
 end
 ]
 
 charsums=[
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	(tt, Set())
+	tt
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, (q-2), congruence)
+	s1=nesum(tt, k, 1, (q-2), congruence)
 	tt1=eesubs(tt, [k], [(q-1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	(1//2*s1-1//2*tt1, e1)
+	1//2*s1-1//2*tt1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	tt1=eesubs(tt, [k], [(q+1)*1//2])
-	tt2=eesubs(tt, [k], [(q+1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
-end,
-function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*1//2])
 	tt2=eesubs(tt, [k], [(q+1)*1//3])
-	(1//2*s1-1//2*tt1-tt2, e1)
+	1//2*s1-1//2*tt1-tt2
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q-2, congruence)
-	s2,e2=nesum(s1, l, 1, q-2, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
+	tt1=eesubs(tt, [k], [(q+1)*1//2])
+	tt2=eesubs(tt, [k], [(q+1)*1//3])
+	1//2*s1-1//2*tt1-tt2
+end,
+function (tt::Cyclotomic)
+	s1=nesum(tt, k, 1, q-2, congruence)
+	s2=nesum(s1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q-2, congruence)
+	s3=nesum(tt1, l, 1, q-2, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q-2, congruence)
+	s4=nesum(tt1, k, 1, q-2, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q-2, congruence)
+	s5=nesum(tt1, l, 1, q-2, congruence)
 	s6=eesubs(tt, [k,l], S.([(q-1)*1//2,(q-1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q-1)*1//2,0]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q, congruence)
-	s2,e2=nesum(s1, l, 1, q, congruence)
+	s1=nesum(tt, k, 1, q, congruence)
+	s2=nesum(s1, l, 1, q, congruence)
 	tt1=eesubs(tt, [k], [l])
-	s3,e3=nesum(tt1, l, 1, q, congruence)
+	s3=nesum(tt1, l, 1, q, congruence)
 	tt1=eesubs(tt, [l], [2*k])
-	s4,e4=nesum(tt1, k, 1, q, congruence)
+	s4=nesum(tt1, k, 1, q, congruence)
 	tt1=eesubs(tt, [k], [-l])
-	s5,e5=nesum(tt1, l, 1, q, congruence)
+	s5=nesum(tt1, l, 1, q, congruence)
 	s6=eesubs(tt, [k,l], S.([(q+1)*1//2,(q+1)*1//2]))
 	s7=eesubs(tt, [k,l], S.([(q+1)*1//2,0]))
 	s8=eesubs(tt, [k,l], S.([(q+1)*1//3,2*(q+1)*1//3]))
 	s9=eesubs(tt, [k,l], S.([2*(q+1)*1//3,(q+1)*1//3]))
-	(1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9, union(e1,e2,e3,e4,e5))
+	1//12*s2-1//12*s3-1//6*s4-1//12*s5+1//12*s6+1//6*s7+1//6*s8+1//6*s9
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-1, congruence)
+	s1=nesum(tt, k, 1, q^2-1, congruence)
 	tt1=eesubs(tt, [k], [(q-1)*k])
-	s2,e2=nesum(tt1, k, 1, q+1, congruence)
+	s2=nesum(tt1, k, 1, q+1, congruence)
 	tt1=eesubs(tt, [k], [(q+1)*k])
-	s3,e3=nesum(tt1, k, 1, q-1, congruence)
+	s3=nesum(tt1, k, 1, q-1, congruence)
 	s4=eesubs(tt, [k], [(q^2-1)*1//2])
 	s5=eesubs(tt, [k], [(q^2-1)])
-	(1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5, union(e1,e2,e3))
+	1//4*s1-1//4*s2-1//4*s3+1//4*s4+1//4*s5
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2+q, congruence)
-	(1//6*s1, e1)
+	s1=nesum(tt, k, 1, q^2+q, congruence)
+	1//6*s1
 end,
 function (tt::Cyclotomic)
-	s1,e1=nesum(tt, k, 1, q^2-q, congruence)
+	s1=nesum(tt, k, 1, q^2-q, congruence)
 	tt1=eesubs(tt, [k], [(q^2-q+1)*1//3])
-	(1//6*s1-1//3*tt1, e1)
+	1//6*s1-1//3*tt1
 end
 ]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ include("Aqua.jl")
 	@test isone((a//c)*(c//a))
 
 	d=e2p(1//(q-1)*i)
-	@test nesum(a, i, 1, q-1)[1]-eesubs(a, [1], [1])==nesum(a, i, 2, q-1)[1]
+	@test nesum(a, i, 1, q-1)-eesubs(a, [1], [1])==nesum(a, i, 2, q-1)
 end
 
 @testset "Shifts" begin
@@ -47,12 +47,12 @@ end
 @testset "setcongruence(table)" begin
 	g=genchartab("SL3.n1")
 	h=tensor!(g,2,2)
-	@test 0 == scalar(g,6,h)[1]
+	@test iszero(scalar(g,6,h))
 	q,(a,b,m,n)=params(g)
 	x=param(g,"x")
 	g2=setcongruence(g, (0,2))
 	speccharparam!(g2, 6, n, -m+(q-1)*x)
-	@test 1 == scalar(g2,6,h)[1]
+	@test isone(scalar(g2,6,h))
 end
 
 @testset "Import green functions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ end
 @testset "setcongruence(table)" begin
 	g=genchartab("SL3.n1")
 	h=tensor!(g,2,2)
-	@test iszero(scalar(g,6,h))
+	@test iszero(scalar(g,6,h), ignore_exceptions=true)
 	q,(a,b,m,n)=params(g)
 	x=param(g,"x")
 	g2=setcongruence(g, (0,2))


### PR DESCRIPTION
It seems like I broke something here. Running the example from #24 now returns less exceptions. Maybe they are still sufficient but it would be nice to see what is going on. And I have to updated the tests...