### PR TITLE
adjust ring restrictions for Cyclo

### DIFF
--- a/src/Arith.jl
+++ b/src/Arith.jl
@@ -42,10 +42,7 @@ abstract type Cyclotomic{T} end
 struct Cyclo{T} <: Cyclotomic{T}
 	modulus::T  # Distance form the origin as polynomial in one variable over some real number field
 	argument::FracPoly{T} # Angle as multiple of 2π
-	function Cyclo(modulus::T, argument::FracPoly{T}; simplify::Bool=true) where T<:NfPoly
-		if parent(modulus)!=base_ring(base_ring(parent(argument)))
-			error("Base rings of modulus and argument do not match!")
-		end
+	function Cyclo(modulus::T, argument::FracPoly{<:NfPoly}; simplify::Bool=true) where T<:NfPoly
 		if simplify
 			if iszero(modulus)
 				return new{T}(modulus, zero(argument))

--- a/src/Show.jl
+++ b/src/Show.jl
@@ -615,7 +615,7 @@ julia> params(g)
 ```
 """
 function params(t::CharTable)
-	q=gen(t.modulusring)
+	q=gen(base_ring(base_ring(t.argumentring)))
 	return (q, Tuple(gens(t.argumentring)[1:nrparams(t)]))
 end
 


### PR DESCRIPTION
This is needed to resolve the root expressions in the exponents of some character tables like 2G2. See for reference #57.