### PR TITLE
fixed usage of modulusring

### DIFF
--- a/src/Congruence.jl
+++ b/src/Congruence.jl
@@ -88,8 +88,9 @@ function simplify(x::Union{Cyclotomic{T}, ParameterException{T}}, t::CharTable{T
 	if t.congruence === nothing
 		return x
 	else
-		c=t.congruence[2]*gen(t.modulusring)+t.congruence[1]
-		cinv=(gen(t.modulusring)-t.congruence[1])//t.congruence[2]
+		q=gen(base_ring(base_ring(t.argumentring)))
+		c=t.congruence[2]*q+t.congruence[1]
+		cinv=(q-t.congruence[1])//t.congruence[2]
 		return simplify(x, c, cinv)
 	end
 end


### PR DESCRIPTION
As we have dropped all relations between the modulusrings and the argumentrings we need to stop mixing them up. This is a follow up of #79.