### PR TITLE
Revert exponent rationalization efforts

### DIFF
--- a/src/Arith.jl
+++ b/src/Arith.jl
@@ -42,7 +42,10 @@ abstract type Cyclotomic{T} end
 struct Cyclo{T} <: Cyclotomic{T}
 	modulus::T  # Distance form the origin as polynomial in one variable over some real number field
 	argument::FracPoly{T} # Angle as multiple of 2π
-	function Cyclo(modulus::T, argument::FracPoly{<:NfPoly}; simplify::Bool=true) where T<:NfPoly
+	function Cyclo(modulus::T, argument::FracPoly{T}; simplify::Bool=true) where T<:NfPoly
+		if parent(modulus)!=base_ring(base_ring(parent(argument)))
+			error("Base rings of modulus and argument do not match!")
+		end
 		if simplify
 			if iszero(modulus)
 				return new{T}(modulus, zero(argument))

--- a/src/Congruence.jl
+++ b/src/Congruence.jl
@@ -88,9 +88,8 @@ function simplify(x::Union{Cyclotomic{T}, ParameterException{T}}, t::CharTable{T
 	if t.congruence === nothing
 		return x
 	else
-		q=gen(base_ring(base_ring(t.argumentring)))
-		c=t.congruence[2]*q+t.congruence[1]
-		cinv=(q-t.congruence[1])//t.congruence[2]
+		c=t.congruence[2]*gen(t.modulusring)+t.congruence[1]
+		cinv=(gen(t.modulusring)-t.congruence[1])//t.congruence[2]
 		return simplify(x, c, cinv)
 	end
 end

--- a/src/Show.jl
+++ b/src/Show.jl
@@ -615,7 +615,7 @@ julia> params(g)
 ```
 """
 function params(t::CharTable)
-	q=gen(base_ring(base_ring(t.argumentring)))
+	q=gen(t.modulusring)
 	return (q, Tuple(gens(t.argumentring)[1:nrparams(t)]))
 end
 


### PR DESCRIPTION
I was a bit quick with those. While converting the 2B2 table locally to rational exponents I noticed many other problems that prevented importing. Finally I could resolve all of these just to notice that the whole concept is flawed. Take a look at `nesum` where it is mathematically necessary to have a well defined multiplication of `modulusring` elements into the `argumentring`. We could work around these by using the mapping between `q` and `q0` but I think this makes things way to complicated.
My new idea is now to fully integrate the `congruence` field of the tables into the simplification of the cyclotomics. All tables with nonrational expressions in their character values have a congruence which ensures rationality in the exponents. This way we can use something like [`change_base_ring`](https://docs.oscar-system.org/stable/AbstractAlgebra/polynomial/#change_base_ring-Union{Tuple{T},%20Tuple{Ring,%20PolyRingElem{T}}}%20where%20T%3C:RingElement) to ensure rationality while applying the normal form algorithms.

@fingolfin I'm not sure if this is how you like reverts to be done but I didn't want to force push to master.