### PR TITLE
Update UnivPolyRing usage

### DIFF
--- a/src/GenericCharacterTables.jl
+++ b/src/GenericCharacterTables.jl
@@ -19,7 +19,7 @@ module GenericCharacterTables
 using Oscar
 import Oscar.AbstractAlgebra.Generic
 
-const FracPoly{T} = Generic.UnivPoly{Generic.FracFieldElem{T}, Generic.MPoly{Generic.FracFieldElem{T}}} where T
+const FracPoly{T} = Generic.UnivPoly{Generic.FracFieldElem{T}} where T
 const NfPoly = Union{PolyRingElem{QQFieldElem}, PolyRingElem{AbsSimpleNumFieldElem}}
 
 include("Parameter.jl")


### PR DESCRIPTION
An approach to fixing the issue described in https://github.com/Nemocas/AbstractAlgebra.jl/pull/1748#issuecomment-2227892485.

If this both works on the master and the release-0.2 branch, releasing this on both branches would make https://github.com/Nemocas/AbstractAlgebra.jl/pull/1748 non-breaking. 