### PR TITLE
[Backport 0.2] Make compatible with Abstractalgebra 0.42

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GenericCharacterTables"
 uuid = "fdcc7804-6c20-4e83-8118-baad6b7d05b7"
 authors = ["Andreas Leim <leim@rhrk.uni-kl.de>", "Martin Wagner <marwagne@rhrk.uni-kl.de>", "Max Horn <mhorn@rptu.de>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/src/Arith.jl
+++ b/src/Arith.jl
@@ -1,6 +1,6 @@
 export e2p
 
-const FracPoly{T} = Generic.UnivPoly{Generic.FracFieldElem{T}, Generic.MPoly{Generic.FracFieldElem{T}}} where T
+const FracPoly{T} = Generic.UnivPoly{Generic.FracFieldElem{T}} where T
 const NfPoly = Union{PolyRingElem{QQFieldElem}, PolyRingElem{AbsSimpleNumFieldElem}}
 
 """

--- a/src/Arith.jl
+++ b/src/Arith.jl
@@ -175,7 +175,7 @@ julia> R, q = polynomial_ring(QQ, \"q\");
 
 julia> Q = fraction_field(R);
 
-julia> S = UniversalPolynomialRing(Q);
+julia> S = universal_polynomial_ring(Q);
 
 julia> i, j = gens(S, [\"i\", \"j\"]);
 

--- a/src/CharTable.jl
+++ b/src/CharTable.jl
@@ -49,7 +49,7 @@ struct CharTable{T} <: Table{T}
 	charparams::Vector{Parameters{T}}  # Info about the parameters of each character type
 	congruence::Union{Tuple{T, T}, Nothing}  # Congruence of the main parameter q (of T). q is congruent to congruence[1] mod congruence[2].
 	modulusring::PolyRing  # Ring of polynomials of type T used in table (also ring of modulus of Cyclotomics)
-	argumentring::Generic.UniversalPolyRing{Generic.FracFieldElem{T}, Generic.MPoly{Generic.FracFieldElem{T}}}  # Ring of argument of the Cyclotomics in table
+	argumentring::Generic.UniversalPolyRing{Generic.FracFieldElem{T}}  # Ring of argument of the Cyclotomics in table
 	information::String  # General info about the table
 end
 

--- a/src/Convert/Convert.jl
+++ b/src/Convert/Convert.jl
@@ -118,7 +118,7 @@ function readmaple(path::String, folder::String)
 	if !NurPolynom
 		summationsprozeduren = convert_summen_parameter(removecomments(String(summationsprozeduren)),cht, clt, joinedparams)
 		imports="using ..GenericCharacterTables\nimport ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterException, ParameterSubstitution, ExtendableMatrix, CharTable\nusing Oscar\n"
-		head = "R, q = polynomial_ring(QQ, \"q\")\nQ = fraction_field(R)\nS = UniversalPolynomialRing(Q, cached=false)\n"
+		head = "R, q = polynomial_ring(QQ, \"q\")\nQ = fraction_field(R)\nS = universal_polynomial_ring(Q; cached=false)\n"
 		ring = join(rr[1:nrpar],",")*", _...=gens(S, "*repr(rr)*")\n"
 	end
 

--- a/src/PrintToTex/Factor.jl
+++ b/src/PrintToTex/Factor.jl
@@ -207,7 +207,7 @@ julia> R, q = polynomial_ring(QQ, \"q\");
 
 julia> Q = fraction_field(R);
 
-julia> S = UniversalPolynomialRing(Q);
+julia> S = universal_polynomial_ring(Q);
 
 julia> i, j = gens(S, [\"i\", \"j\"]);
 

--- a/src/SumProc.jl
+++ b/src/SumProc.jl
@@ -50,7 +50,7 @@ julia> R, q = polynomial_ring(QQ, \"q\");
 
 julia> Q=fraction_field(R);
 
-julia> S=UniversalPolynomialRing(Q);
+julia> S=universal_polynomial_ring(Q);
 
 julia> i, j, k, l = gens(S, [\"i\", \"j\", \"k\", \"l\"]);
 
@@ -88,7 +88,7 @@ julia> R, q = polynomial_ring(QQ, "q");
 
 julia> Q=fraction_field(R);
 
-julia> S=UniversalPolynomialRing(Q);
+julia> S=universal_polynomial_ring(Q);
 
 julia> i, = gens(S, ["i"]);
 

--- a/src/Tables/2A2/GU3.jl
+++ b/src/Tables/2A2/GU3.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 k,l,m,u,v,w, _...=gens(S, ["k", "l", "m", "u", "v", "w", "k1", "l1", "m1", "u1", "v1", "w1", "k2", "l2", "m2", "u2", "v2", "w2", "k3", "l3", "m3", "u3", "v3", "w3", "kt1", "lt1", "mt1", "ut1", "vt1", "wt1", "kt2", "lt2", "mt2", "ut2", "vt2", "wt2"])
 
 order = q^3*(q+1)^3*(q-1)*(q^2-q+1)

--- a/src/Tables/2A2/PGU3.2.jl
+++ b/src/Tables/2A2/PGU3.2.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 k,l,u,v, _...=gens(S, ["k", "l", "u", "v", "k1", "l1", "u1", "v1", "k2", "l2", "u2", "v2", "k3", "l3", "u3", "v3", "kt1", "lt1", "ut1", "vt1", "kt2", "lt2", "ut2", "vt2"])
 
 order = q^3*(q+1)^2*(q-1)*(q^2-q+1)

--- a/src/Tables/2A2/PSU3.2.jl
+++ b/src/Tables/2A2/PSU3.2.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,m,n, _...=gens(S, ["a", "b", "m", "n", "a1", "b1", "m1", "n1", "a2", "b2", "m2", "n2", "a3", "b3", "m3", "n3", "at1", "bt1", "mt1", "nt1", "at2", "bt2", "mt2", "nt2"])
 
 order = q^3*(q+1)^2*(q-1)*(q^2-q+1)*1//3

--- a/src/Tables/2A2/SU3.2.jl
+++ b/src/Tables/2A2/SU3.2.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,m,n, _...=gens(S, ["a", "b", "m", "n", "a1", "b1", "m1", "n1", "a2", "b2", "m2", "n2", "a3", "b3", "m3", "n3", "at1", "bt1", "mt1", "nt1", "at2", "bt2", "mt2", "nt2"])
 
 order = q^3*(q+1)^2*(q-1)*(q^2-q+1)

--- a/src/Tables/2A2/SU3.n2.jl
+++ b/src/Tables/2A2/SU3.n2.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,m,n, _...=gens(S, ["a", "b", "m", "n", "a1", "b1", "m1", "n1", "a2", "b2", "m2", "n2", "a3", "b3", "m3", "n3", "at1", "bt1", "mt1", "nt1", "at2", "bt2", "mt2", "nt2"])
 
 order = q^3*(q+1)^2*(q-1)*(q^2-q+1)

--- a/src/Tables/2B2/2B2.jl
+++ b/src/Tables/2B2/2B2.jl
@@ -4,7 +4,7 @@ using Oscar
 K, sqrt2 = quadratic_field(2)
 R, q = polynomial_ring(K, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,c,s,k,u, _...=gens(S, ["a", "b", "c", "s", "k", "u", "a1", "b1", "c1", "s1", "k1", "u1", "a2", "b2", "c2", "s2", "k2", "u2", "a3", "b3", "c3", "s3", "k3", "u3", "at1", "bt1", "ct1", "st1", "kt1", "ut1", "at2", "bt2", "ct2", "st2", "kt2", "ut2"])
 
 order = q^4*(q^4+1)*(q^2-1)

--- a/src/Tables/2F4/2F4.1.jl
+++ b/src/Tables/2F4/2F4.1.jl
@@ -6,7 +6,7 @@ sqrt2 = 1//2*d^3 - 9//2*d
 sqrt3 = -1//2*d^3 + 11//2*d
 R, q = polynomial_ring(K, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,k,l, _...=gens(S, ["a", "b", "k", "l", "a1", "b1", "k1", "l1", "a2", "b2", "k2", "l2", "a3", "b3", "k3", "l3", "at1", "bt1", "kt1", "lt1", "at2", "bt2", "kt2", "lt2"])
 
 order = q^24*(q^12+1)*(q^8-1)*(q^6+1)*(q^2-1)

--- a/src/Tables/2F4/2F4.2.jl
+++ b/src/Tables/2F4/2F4.2.jl
@@ -6,7 +6,7 @@ sqrt2 = 1//2*d^3 - 9//2*d
 sqrt3 = -1//2*d^3 + 11//2*d
 R, q = polynomial_ring(K, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,k,l, _...=gens(S, ["a", "b", "k", "l", "a1", "b1", "k1", "l1", "a2", "b2", "k2", "l2", "a3", "b3", "k3", "l3", "at1", "bt1", "kt1", "lt1", "at2", "bt2", "kt2", "lt2"])
 
 order = q^24*(q^12+1)*(q^8-1)*(q^6+1)*(q^2-1)

--- a/src/Tables/2G2/2G2.jl
+++ b/src/Tables/2G2/2G2.jl
@@ -4,7 +4,7 @@ using Oscar
 K, sqrt3 = quadratic_field(3)
 R, q = polynomial_ring(K, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,k,l, _...=gens(S, ["i", "j", "k", "l", "i1", "j1", "k1", "l1", "i2", "j2", "k2", "l2", "i3", "j3", "k3", "l3", "it1", "jt1", "kt1", "lt1", "it2", "jt2", "kt2", "lt2"])
 
 order = q^6*(q^2+1+q*sqrt3)*(q^2+1-q*sqrt3)*(q^2+1)*(q-1)*(q+1)

--- a/src/Tables/3D4/3D4.0.jl
+++ b/src/Tables/3D4/3D4.0.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,k,l, _...=gens(S, ["a", "b", "k", "l", "a1", "b1", "k1", "l1", "a2", "b2", "k2", "l2", "a3", "b3", "k3", "l3", "at1", "bt1", "kt1", "lt1", "at2", "bt2", "kt2", "lt2"])
 
 order = q^12*(q^8+q^4+1)*(q^6-1)*(q^2-1)

--- a/src/Tables/3D4/3D4.11.jl
+++ b/src/Tables/3D4/3D4.11.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,k,l, _...=gens(S, ["a", "b", "k", "l", "a1", "b1", "k1", "l1", "a2", "b2", "k2", "l2", "a3", "b3", "k3", "l3", "at1", "bt1", "kt1", "lt1", "at2", "bt2", "kt2", "lt2"])
 
 order = q^12*(q^8+q^4+1)*(q^6-1)*(q^2-1)

--- a/src/Tables/3D4/3D4.13.jl
+++ b/src/Tables/3D4/3D4.13.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,k,l, _...=gens(S, ["a", "b", "k", "l", "a1", "b1", "k1", "l1", "a2", "b2", "k2", "l2", "a3", "b3", "k3", "l3", "at1", "bt1", "kt1", "lt1", "at2", "bt2", "kt2", "lt2"])
 
 order = q^12*(q^8+q^4+1)*(q^6-1)*(q^2-1)

--- a/src/Tables/A1/GL2.jl
+++ b/src/Tables/A1/GL2.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,l,k, _...=gens(S, ["i", "j", "l", "k", "i1", "j1", "l1", "k1", "i2", "j2", "l2", "k2", "i3", "j3", "l3", "k3", "it1", "jt1", "lt1", "kt1", "it2", "jt2", "lt2", "kt2"])
 
 order = (q^2-1)*(q^2-q)

--- a/src/Tables/A1/GU2.jl
+++ b/src/Tables/A1/GU2.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 k,l,u,v, _...=gens(S, ["k", "l", "u", "v", "k1", "l1", "u1", "v1", "k2", "l2", "u2", "v2", "k3", "l3", "u3", "v3", "kt1", "lt1", "ut1", "vt1", "kt2", "lt2", "ut2", "vt2"])
 
 order = q*(q+1)^2*(q-1)

--- a/src/Tables/A1/PGL2.1.jl
+++ b/src/Tables/A1/PGL2.1.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,l,k, _...=gens(S, ["i", "j", "l", "k", "i1", "j1", "l1", "k1", "i2", "j2", "l2", "k2", "i3", "j3", "l3", "k3", "it1", "jt1", "lt1", "kt1", "it2", "jt2", "lt2", "kt2"])
 
 order = q*(q^2-1)

--- a/src/Tables/A1/PSL2.1.jl
+++ b/src/Tables/A1/PSL2.1.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,k, _...=gens(S, ["i", "k", "i1", "k1", "i2", "k2", "i3", "k3", "it1", "kt1", "it2", "kt2"])
 
 order = q^2*(q^2-1)*(q^2+1)*1//2

--- a/src/Tables/A1/PSL2.3.jl
+++ b/src/Tables/A1/PSL2.3.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,k, _...=gens(S, ["i", "k", "i1", "k1", "i2", "k2", "i3", "k3", "it1", "kt1", "it2", "kt2"])
 
 order = q^2*(q^2-1)*(q^2+1)*1//2

--- a/src/Tables/A1/SL2.0.jl
+++ b/src/Tables/A1/SL2.0.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,n, _...=gens(S, ["a", "n", "a1", "n1", "a2", "n2", "a3", "n3", "at1", "nt1", "at2", "nt2"])
 
 order = q*(q-1)*(q+1)

--- a/src/Tables/A1/SL2.1.jl
+++ b/src/Tables/A1/SL2.1.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,k, _...=gens(S, ["i", "k", "i1", "k1", "i2", "k2", "i3", "k3", "it1", "kt1", "it2", "kt2"])
 
 order = q^2*(q^2-1)*(q^2+1)

--- a/src/Tables/A2/GL3.jl
+++ b/src/Tables/A2/GL3.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,c,l,m,n, _...=gens(S, ["a", "b", "c", "l", "m", "n", "a1", "b1", "c1", "l1", "m1", "n1", "a2", "b2", "c2", "l2", "m2", "n2", "a3", "b3", "c3", "l3", "m3", "n3", "at1", "bt1", "ct1", "lt1", "mt1", "nt1", "at2", "bt2", "ct2", "lt2", "mt2", "nt2"])
 
 order = q^3*(q-1)^3*(q+1)*(q^2+q+1)

--- a/src/Tables/A2/PGL3.1.jl
+++ b/src/Tables/A2/PGL3.1.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,m,n, _...=gens(S, ["a", "b", "m", "n", "a1", "b1", "m1", "n1", "a2", "b2", "m2", "n2", "a3", "b3", "m3", "n3", "at1", "bt1", "mt1", "nt1", "at2", "bt2", "mt2", "nt2"])
 
 order = q^3*(q-1)^2*(q+1)*(q^2+q+1)

--- a/src/Tables/A2/PSL3.1.jl
+++ b/src/Tables/A2/PSL3.1.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,m,n, _...=gens(S, ["a", "b", "m", "n", "a1", "b1", "m1", "n1", "a2", "b2", "m2", "n2", "a3", "b3", "m3", "n3", "at1", "bt1", "mt1", "nt1", "at2", "bt2", "mt2", "nt2"])
 
 order = q^3*(q-1)^2*(q+1)*(q^2+q+1)*1//3

--- a/src/Tables/A2/SL3.1.jl
+++ b/src/Tables/A2/SL3.1.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,m,n, _...=gens(S, ["a", "b", "m", "n", "a1", "b1", "m1", "n1", "a2", "b2", "m2", "n2", "a3", "b3", "m3", "n3", "at1", "bt1", "mt1", "nt1", "at2", "bt2", "mt2", "nt2"])
 
 order = q^3*(q-1)^2*(q+1)*(q^2+q+1)

--- a/src/Tables/A2/SL3.n1.jl
+++ b/src/Tables/A2/SL3.n1.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 a,b,m,n, _...=gens(S, ["a", "b", "m", "n", "a1", "b1", "m1", "n1", "a2", "b2", "m2", "n2", "a3", "b3", "m3", "n3", "at1", "bt1", "mt1", "nt1", "at2", "bt2", "mt2", "nt2"])
 
 order = q^3*(q-1)^2*(q+1)*(q^2+q+1)

--- a/src/Tables/C2/Sp4.0.jl
+++ b/src/Tables/C2/Sp4.0.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,k,l, _...=gens(S, ["i", "j", "k", "l", "i1", "j1", "k1", "l1", "i2", "j2", "k2", "l2", "i3", "j3", "k3", "l3", "it1", "jt1", "kt1", "lt1", "it2", "jt2", "kt2", "lt2"])
 
 order = q^4*(q-1)^2*(q+1)^2*(q^2+1)

--- a/src/Tables/C3/CSp6.1.jl
+++ b/src/Tables/C3/CSp6.1.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i1,i2,i3,i4,k1,k2,k3,k4,i11, _...=gens(S, ["i1", "i2", "i3", "i4", "k1", "k2", "k3", "k4", "i11", "i21", "i31", "i41", "k11", "k21", "k31", "k41", "i12", "i22", "i32", "i42", "k12", "k22", "k32", "k42", "i13", "i23", "i33", "i43", "k13", "k23", "k33", "k43", "i1t1", "i2t1", "i3t1", "i4t1", "k1t1", "k2t1", "k3t1", "k4t1", "i1t2", "i2t2", "i3t2", "i4t2", "k1t2", "k2t2", "k3t2", "k4t2"])
 
 order = q^9*(q^6-1)*(q^4-1)*(q^2-1)*(q-1)

--- a/src/Tables/C3/Sp6.0.jl
+++ b/src/Tables/C3/Sp6.0.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i1,i2,i3,k1,k2,k3, _...=gens(S, ["i1", "i2", "i3", "k1", "k2", "k3", "i11", "i21", "i31", "k11", "k21", "k31", "i12", "i22", "i32", "k12", "k22", "k32", "i13", "i23", "i33", "k13", "k23", "k33", "i1t1", "i2t1", "i3t1", "k1t1", "k2t1", "k3t1", "i1t2", "i2t2", "i3t2", "k1t2", "k2t2", "k3t2"])
 
 order = q^9*(q^6-1)*(q^4-1)*(q^2-1)

--- a/src/Tables/F4/uniuniF4p2.jl
+++ b/src/Tables/F4/uniuniF4p2.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 
 order = q^24*(q^4-q^2+1)*(q^4+1)*(q^2+q+1)^2*(q^2-q+1)^2*(q^2+1)^2*(q-1)^4*(q+1)^4
 table = Cyclotomic{QQPolyRingElem}[[

--- a/src/Tables/G2/G2.01.jl
+++ b/src/Tables/G2/G2.01.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,k,l, _...=gens(S, ["i", "j", "k", "l", "i1", "j1", "k1", "l1", "i2", "j2", "k2", "l2", "i3", "j3", "k3", "l3", "it1", "jt1", "kt1", "lt1", "it2", "jt2", "kt2", "lt2"])
 
 order = q^6*(q^2-1)^2*(q^4+q^2+1)

--- a/src/Tables/G2/G2.02.jl
+++ b/src/Tables/G2/G2.02.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,k,l, _...=gens(S, ["i", "j", "k", "l", "i1", "j1", "k1", "l1", "i2", "j2", "k2", "l2", "i3", "j3", "k3", "l3", "it1", "jt1", "kt1", "lt1", "it2", "jt2", "kt2", "lt2"])
 
 order = q^6*(q^2-1)^2*(q^4+q^2+1)

--- a/src/Tables/G2/G2.101.jl
+++ b/src/Tables/G2/G2.101.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,k,l, _...=gens(S, ["i", "j", "k", "l", "i1", "j1", "k1", "l1", "i2", "j2", "k2", "l2", "i3", "j3", "k3", "l3", "it1", "jt1", "kt1", "lt1", "it2", "jt2", "kt2", "lt2"])
 
 order = q^6*(q^2-1)^2*(q^4+q^2+1)

--- a/src/Tables/G2/G2.103.jl
+++ b/src/Tables/G2/G2.103.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,k,l, _...=gens(S, ["i", "j", "k", "l", "i1", "j1", "k1", "l1", "i2", "j2", "k2", "l2", "i3", "j3", "k3", "l3", "it1", "jt1", "kt1", "lt1", "it2", "jt2", "kt2", "lt2"])
 
 order = q^6*(q^2-1)^2*(q^4+q^2+1)

--- a/src/Tables/G2/G2.111.jl
+++ b/src/Tables/G2/G2.111.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,k,l, _...=gens(S, ["i", "j", "k", "l", "i1", "j1", "k1", "l1", "i2", "j2", "k2", "l2", "i3", "j3", "k3", "l3", "it1", "jt1", "kt1", "lt1", "it2", "jt2", "kt2", "lt2"])
 
 order = q^6*(q^2-1)^2*(q^4+q^2+1)

--- a/src/Tables/G2/G2.113.jl
+++ b/src/Tables/G2/G2.113.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,k,l, _...=gens(S, ["i", "j", "k", "l", "i1", "j1", "k1", "l1", "i2", "j2", "k2", "l2", "i3", "j3", "k3", "l3", "it1", "jt1", "kt1", "lt1", "it2", "jt2", "kt2", "lt2"])
 
 order = q^6*(q^2-1)^2*(q^4+q^2+1)

--- a/src/Tables/G2/G2.121.jl
+++ b/src/Tables/G2/G2.121.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,k,l, _...=gens(S, ["i", "j", "k", "l", "i1", "j1", "k1", "l1", "i2", "j2", "k2", "l2", "i3", "j3", "k3", "l3", "it1", "jt1", "kt1", "lt1", "it2", "jt2", "kt2", "lt2"])
 
 order = q^6*(q^2-1)^2*(q^4+q^2+1)

--- a/src/Tables/G2/G2.123.jl
+++ b/src/Tables/G2/G2.123.jl
@@ -3,7 +3,7 @@ import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterExc
 using Oscar
 R, q = polynomial_ring(QQ, "q")
 Q = fraction_field(R)
-S = UniversalPolynomialRing(Q, cached=false)
+S = universal_polynomial_ring(Q; cached=false)
 i,j,k,l, _...=gens(S, ["i", "j", "k", "l", "i1", "j1", "k1", "l1", "i2", "j2", "k2", "l2", "i3", "j3", "k3", "l3", "it1", "jt1", "kt1", "lt1", "it2", "jt2", "kt2", "lt2"])
 
 order = q^6*(q^2-1)^2*(q^4+q^2+1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ include("Aqua.jl")
 @testset "Cyclotomic" begin
 	R, q = polynomial_ring(QQ, "q")
 	Q = fraction_field(R)
-	S = UniversalPolynomialRing(Q)
+	S = universal_polynomial_ring(Q)
 	i, j = gens(S, ["i", "j"])
 
 	a=e2p(1//(q-1)*i+2//(q-1)*j+q^2//(q+1)*i)


### PR DESCRIPTION
Backports #84 and #87.

This needs the creation of a release-0.2 branch and then this PR's base-branch changed to this.

This would make it possible to use #84 and #87 in proceeding with https://github.com/oscar-system/Oscar.jl/pull/3958 without needing to care about https://github.com/oscar-system/GenericCharacterTables.jl/issues/88 for the moment.