### PR TITLE
rationalized 2B2

### DIFF
--- a/data/Tables/2B2/2B2.jl
+++ b/data/Tables/2B2/2B2.jl
@@ -1,14 +1,13 @@
 using ..GenericCharacterTables
 import ..GenericCharacterTables: Cyclotomic, Parameters, Parameter, ParameterException, CharTable
 using Oscar
-K, sqrt2 = quadratic_field(2)
-R, q = polynomial_ring(K, "q")
+R, q0 = polynomial_ring(QQ, "q0")
 Q = fraction_field(R)
 S = universal_polynomial_ring(Q; cached=false)
 a,b,c,s,k,u, _...=gens(S, ["a", "b", "c", "s", "k", "u", "a1", "b1", "c1", "s1", "k1", "u1", "a2", "b2", "c2", "s2", "k2", "u2", "a3", "b3", "c3", "s3", "k3", "u3", "at1", "bt1", "ct1", "st1", "kt1", "ut1", "at2", "bt2", "ct2", "st2", "kt2", "ut2"])
 
-order = q^4*(q^4+1)*(q^2-1)
-table = Cyclotomic{Generic.Poly{AbsSimpleNumFieldElem}}[[
+order = 4*q0^4*(4*q0^4+1)*(2*q0^2-1)
+table = Cyclotomic{QQPolyRingElem}[[
 	CycloSum(R(1), S(0)),
 	CycloSum(R(1), S(0)),
 	CycloSum(R(1), S(0)),
@@ -16,48 +15,48 @@ table = Cyclotomic{Generic.Poly{AbsSimpleNumFieldElem}}[[
 	CycloSum(R(1), S(0)),
 	CycloSum(R(1), S(0)),
 	CycloSum(R(1), S(0))] [
-	(q*1//sqrt2*(q^2-1))*CycloSum(R(1), S(0)),
-	(-q*1//sqrt2)*CycloSum(R(1), S(0)),
-	q*1//sqrt2*CycloSum(R(1), S(1//(4))),
-	-q*1//sqrt2*CycloSum(R(1), S(1//(4))),
+	(q0*(2*q0^2-1))*CycloSum(R(1), S(0)),
+	(-q0)*CycloSum(R(1), S(0)),
+	q0*CycloSum(R(1), S(1//(4))),
+	-q0*CycloSum(R(1), S(1//(4))),
 	CycloSum(R(0), S(0)),
 	CycloSum(R(1), S(0)),
 	-CycloSum(R(1), S(0))] [
-	(q*1//sqrt2*(q^2-1))*CycloSum(R(1), S(0)),
-	(-q*1//sqrt2)*CycloSum(R(1), S(0)),
-	-q*1//sqrt2*CycloSum(R(1), S(1//(4))),
-	q*1//sqrt2*CycloSum(R(1), S(1//(4))),
+	(q0*(2*q0^2-1))*CycloSum(R(1), S(0)),
+	(-q0)*CycloSum(R(1), S(0)),
+	-q0*CycloSum(R(1), S(1//(4))),
+	q0*CycloSum(R(1), S(1//(4))),
 	CycloSum(R(0), S(0)),
 	CycloSum(R(1), S(0)),
 	-CycloSum(R(1), S(0))] [
-	(q^4)*CycloSum(R(1), S(0)),
+	(4*q0^4)*CycloSum(R(1), S(0)),
 	CycloSum(R(0), S(0)),
 	CycloSum(R(0), S(0)),
 	CycloSum(R(0), S(0)),
 	CycloSum(R(1), S(0)),
 	-CycloSum(R(1), S(0)),
 	-CycloSum(R(1), S(0))] [
-	(q^4+1)*CycloSum(R(1), S(0)),
+	(4*q0^4+1)*CycloSum(R(1), S(0)),
 	CycloSum(R(1), S(0)),
 	CycloSum(R(1), S(0)),
 	CycloSum(R(1), S(0)),
-	CycloSum(R(1), (s*a)*S(1//(q^2-1)))+CycloSum(R(1), (-s*a)*S(1//(q^2-1))),
+	CycloSum(R(1), (s*a)*S(1//(2*q0^2-1)))+CycloSum(R(1), (-s*a)*S(1//(2*q0^2-1))),
 	CycloSum(R(0), S(0)),
 	CycloSum(R(0), S(0))] [
-	((q^2-1)*(q^2-sqrt2*q+1))*CycloSum(R(1), S(0)),
-	(sqrt2*q-1)*CycloSum(R(1), S(0)),
+	((2*q0^2-1)*(2*q0^2-2*q0+1))*CycloSum(R(1), S(0)),
+	(2*q0-1)*CycloSum(R(1), S(0)),
 	-CycloSum(R(1), S(0)),
 	-CycloSum(R(1), S(0)),
 	CycloSum(R(0), S(0)),
-	-(CycloSum(R(1), (k*b)*S(1//(q^2+sqrt2*q+1)))+CycloSum(R(1), (-k*b)*S(1//(q^2+sqrt2*q+1)))+CycloSum(R(1), (q^2*k*b)*S(1//(q^2+sqrt2*q+1)))+CycloSum(R(1), (-q^2*k*b)*S(1//(q^2+sqrt2*q+1)))),
+	-(CycloSum(R(1), (k*b)*S(1//(2*q0^2+2*q0+1)))+CycloSum(R(1), (-k*b)*S(1//(2*q0^2+2*q0+1)))+CycloSum(R(1), (2*q0^2*k*b)*S(1//(2*q0^2+2*q0+1)))+CycloSum(R(1), (-2*q0^2*k*b)*S(1//(2*q0^2+2*q0+1)))),
 	CycloSum(R(0), S(0))] [
-	((q^2-1)*(q^2+sqrt2*q+1))*CycloSum(R(1), S(0)),
-	(-sqrt2*q-1)*CycloSum(R(1), S(0)),
+	((2*q0^2-1)*(2*q0^2+2*q0+1))*CycloSum(R(1), S(0)),
+	(-2*q0-1)*CycloSum(R(1), S(0)),
 	-CycloSum(R(1), S(0)),
 	-CycloSum(R(1), S(0)),
 	CycloSum(R(0), S(0)),
 	CycloSum(R(0), S(0)),
-	-(CycloSum(R(1), (u*c)*S(1//(q^2-sqrt2*q+1)))+CycloSum(R(1), (-u*c)*S(1//(q^2-sqrt2*q+1)))+CycloSum(R(1), (q^2*u*c)*S(1//(q^2-sqrt2*q+1)))+CycloSum(R(1), (-q^2*u*c)*S(1//(q^2-sqrt2*q+1))))]]
+	-(CycloSum(R(1), (u*c)*S(1//(2*q0^2-2*q0+1)))+CycloSum(R(1), (-u*c)*S(1//(2*q0^2-2*q0+1)))+CycloSum(R(1), (2*q0^2*u*c)*S(1//(2*q0^2-2*q0+1)))+CycloSum(R(1), (-2*q0^2*u*c)*S(1//(2*q0^2-2*q0+1))))]]
 classinfo = [
 	[[1,0],["^2B_2","u_0"]],
 	[[1,1],["^2B_2","u_1"]],
@@ -68,12 +67,12 @@ classinfo = [
 	[[4,0],["A_0",[1]]]]
 classlength = R.([
 	1,
-	(q^2-1)*(q^4+1),
-	q^2*1//2*(q^2-1)*(q^4+1),
-	q^2*1//2*(q^2-1)*(q^4+1),
-	q^4*(q^4+1),
-	q^4*(q^2-1)*(q^2-sqrt2*q+1),
-	q^4*(q^2-1)*(q^2+sqrt2*q+1)])
+	(2*q0^2-1)*(4*q0^4+1),
+	2*q0^2*1//2*(2*q0^2-1)*(4*q0^4+1),
+	2*q0^2*1//2*(2*q0^2-1)*(4*q0^4+1),
+	4*q0^4*(4*q0^4+1),
+	4*q0^4*(2*q0^2-1)*(2*q0^2-2*q0+1),
+	4*q0^4*(2*q0^2-1)*(2*q0^2+2*q0+1)])
 charinfo = [
 	[[1,0],["^2B_2","1"],"1"],
 	[[1,1],["^2B_2","2B2[a]"],"2B2[a]"],
@@ -82,7 +81,7 @@ charinfo = [
 	[[2,0],["A_0",[1]],"chi5"],
 	[[3,0],["A_0",[1]],"chi6"],
 	[[4,0],["A_0",[1]],"chi7"]]
-chardegree = R.([1, q*1//sqrt2*(q^2-1), q*1//sqrt2*(q^2-1), q^4, q^4+1, (q^2-1)*(q^2-sqrt2*q+1), (q^2-1)*(q^2+sqrt2*q+1)])
+chardegree = R.([1, q0*(2*q0^2-1), q0*(2*q0^2-1), 4*q0^4, 4*q0^4+1, (2*q0^2-1)*(2*q0^2-2*q0+1), (2*q0^2-1)*(2*q0^2+2*q0+1)])
 
 classsums=[
 function (tt::Cyclotomic)
@@ -98,15 +97,15 @@ function (tt::Cyclotomic)
 	tt
 end,
 function (tt::Cyclotomic)
-	s1=nesum(tt, a, 1, q^2-2, congruence)
+	s1=nesum(tt, a, 1, 2*q0^2-2, congruence)
 	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1=nesum(tt, b, 1, q^2+sqrt2*q, congruence)
+	s1=nesum(tt, b, 1, 2*q0^2+2*q0, congruence)
 	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1=nesum(tt, c, 1, q^2-sqrt2*q, congruence)
+	s1=nesum(tt, c, 1, 2*q0^2-2*q0, congruence)
 	1//4*s1
 end
 ]
@@ -125,44 +124,45 @@ function (tt::Cyclotomic)
 	tt
 end,
 function (tt::Cyclotomic)
-	s1=nesum(tt, s, 1, q^2-2, congruence)
+	s1=nesum(tt, s, 1, 2*q0^2-2, congruence)
 	1//2*s1
 end,
 function (tt::Cyclotomic)
-	s1=nesum(tt, k, 1, q^2+sqrt2*q, congruence)
+	s1=nesum(tt, k, 1, 2*q0^2+2*q0, congruence)
 	1//4*s1
 end,
 function (tt::Cyclotomic)
-	s1=nesum(tt, u, 1, q^2-sqrt2*q, congruence)
+	s1=nesum(tt, u, 1, 2*q0^2-2*q0, congruence)
 	1//4*s1
 end
 ]
 
 classparams=[
-Parameters(Parameter{Generic.Poly{AbsSimpleNumFieldElem}}[]),
-Parameters(Parameter{Generic.Poly{AbsSimpleNumFieldElem}}[]),
-Parameters(Parameter{Generic.Poly{AbsSimpleNumFieldElem}}[]),
-Parameters(Parameter{Generic.Poly{AbsSimpleNumFieldElem}}[]),
-Parameters([Parameter(a, q^2-1)], [ParameterException((a)*1//(q^2-1))]),
-Parameters([Parameter(b, q^2+sqrt2*q+1)], [ParameterException((b)*1//(q^2+sqrt2*q+1))]),
-Parameters([Parameter(c, q^2-sqrt2*q+1)], [ParameterException((c)*1//(q^2-sqrt2*q+1))])
+Parameters(Parameter{QQPolyRingElem}[]),
+Parameters(Parameter{QQPolyRingElem}[]),
+Parameters(Parameter{QQPolyRingElem}[]),
+Parameters(Parameter{QQPolyRingElem}[]),
+Parameters([Parameter(a, 2*q0^2-1)], [ParameterException((a)*1//(2*q0^2-1))]),
+Parameters([Parameter(b, 2*q0^2+2*q0+1)], [ParameterException((b)*1//(2*q0^2+2*q0+1))]),
+Parameters([Parameter(c, 2*q0^2-2*q0+1)], [ParameterException((c)*1//(2*q0^2-2*q0+1))])
 ]
 
 charparams=[
-Parameters(Parameter{Generic.Poly{AbsSimpleNumFieldElem}}[]),
-Parameters(Parameter{Generic.Poly{AbsSimpleNumFieldElem}}[]),
-Parameters(Parameter{Generic.Poly{AbsSimpleNumFieldElem}}[]),
-Parameters(Parameter{Generic.Poly{AbsSimpleNumFieldElem}}[]),
-Parameters([Parameter(s, q^2-1)], [ParameterException((s)*1//(q^2-1))]),
-Parameters([Parameter(k, q^2+sqrt2*q+1)], [ParameterException((k)*1//(q^2+sqrt2*q+1))]),
-Parameters([Parameter(u, q^2-sqrt2*q+1)], [ParameterException((u)*1//(q^2-sqrt2*q+1))])
+Parameters(Parameter{QQPolyRingElem}[]),
+Parameters(Parameter{QQPolyRingElem}[]),
+Parameters(Parameter{QQPolyRingElem}[]),
+Parameters(Parameter{QQPolyRingElem}[]),
+Parameters([Parameter(s, 2*q0^2-1)], [ParameterException((s)*1//(2*q0^2-1))]),
+Parameters([Parameter(k, 2*q0^2+2*q0+1)], [ParameterException((k)*1//(2*q0^2+2*q0+1))]),
+Parameters([Parameter(u, 2*q0^2-2*q0+1)], [ParameterException((u)*1//(2*q0^2-2*q0+1))])
 ]
 
 classparamindex=var_index.([a,b,c])
 charparamindex=var_index.([s,k,u])
-congruence=R.((0,sqrt2))
+congruence=nothing
 
-information = raw"""- Information about the generic character table of $^2B_2(q^2)$.
+information = raw"""- Information about the generic character table of $^2B_2(q^2)$,
+  where ``q = \sqrt{2}q_0``.
 
 - CHEVIE-name of the table: ``Sz``
 


### PR DESCRIPTION
To be able to benefit from #82 we need all tables to be free of irrational exponents. Rooty expressions in the coefficients of the generic cyclotomics can be expressed by generic cyclotomics directly without number fields.