### PR TITLE
Fix and improve print_decomposition

### DIFF
--- a/src/Arith.jl
+++ b/src/Arith.jl
@@ -213,6 +213,7 @@ function Base.show(io::IO, z::CycloFrac)
 		for exception in z.exceptions
 			print(io, "\n$(exception)")
 		end
+		print(io, Dedent())
 	end
 end
 Base.show(io::IO, m::MIME{Symbol("text/latex")}, z::CycloFrac) = print(io, "\\frac{$(repr("text/latex", z.numerator))}{$(repr("text/latex",z.denominator))}")

--- a/src/Show.jl
+++ b/src/Show.jl
@@ -562,23 +562,19 @@ end
 printval(t::Table; kwarg...) = printval(stdout, t; kwarg...)
 
 # TODO: document this (and/or replace it by something better)
-function print_decomposition(io::IO, t::CharTable, char::Int)
+function print_decomposition(io::IO, t::CharTable, chi::AbstractGenericCharacter)
 	io = pretty(io)
-	print(io, "Decomposing character $char:", Indent())
+	print(io, "Decomposing character chi:", Indent())
 	for i in 1:irrchartypes(t)
 		println(io)
-		s, e = scalar(t, i, char)
-		print(io, "<$i,$char> = $s  ")
-		if !isempty(e)
-			print(io, "with possible exceptions:", Indent())
-			for ex in e
-				print(io, "\n", ex)
-			end
-			print(io, Dedent())
-		end
+		s = scalar(t[i], chi)
+		print(io, "<$i,chi> = ", Indent(), s, Dedent())
 	end
+	print(io, Dedent())
 end
 
+print_decomposition(io::IO, t::CharTable, char::Int) = print_decomposition(io, t, t[char])
+print_decomposition(t::CharTable, char::AbstractGenericCharacter) = print_decomposition(stdout, t, char)
 print_decomposition(t::CharTable, char::Int) = print_decomposition(stdout, t, char)
 export print_decomposition
 


### PR DESCRIPTION
It now works again and also accepts stand alone characters
as input, not just the id of an irreducible character (type).

The printing was also slightly tweaked, and a bug fixed in the
show method for `CycloFrac` which omitted a final `Dedent()`.


This is still missing a proper test case, though... @SoongNoonien please add one