### PR TITLE
Misc changes

### DIFF
--- a/src/Ortho.jl
+++ b/src/Ortho.jl
@@ -45,6 +45,14 @@ end
     norm(char::AbstractGenericCharacter{T}) where T <: NfPoly
 
 Return the norm of the character type `char`.
+
+# Examples
+```jldoctest
+julia> g=genchartab("GL2");
+
+julia> norm(g[1])
+1
+```
 """
 function Oscar.norm(char::GenericCharacter{T}) where T <: NfPoly
 	t=parent(char)
@@ -75,7 +83,6 @@ julia> g=genchartab("GL2");
 
 julia> norm(g,1)
 1
-
 ```
 """
 function Oscar.norm(t::Table{T}, char::Int64) where T <: NfPoly
@@ -90,6 +97,17 @@ end
 
 Return the scalar product between the character types `char1` and `char2`.
 
+# Examples
+```jldoctest
+julia> g=genchartab("GL2");
+
+julia> scalar(g[3],g[2])
+0
+With exceptions:
+  l1 + k1 - 2*k2 ∈ (q - 1)ℤ
+  l1 - k2 ∈ (q - 1)ℤ
+  k1 - k2 ∈ (q - 1)ℤ
+```
 """
 function scalar(char1::GenericCharacter{T}, char2::GenericCharacter{T}) where T <: NfPoly
 	if parent(char1) != parent(char2)

--- a/src/Ortho.jl
+++ b/src/Ortho.jl
@@ -89,8 +89,8 @@ end
     scalar(char1::AbstractGenericCharacter{T}, char2::AbstractGenericCharacter{T}) where T <: NfPoly
 
 Return the scalar product between the character types `char1` and `char2`.
-"""
 
+"""
 function scalar(char1::GenericCharacter{T}, char2::GenericCharacter{T}) where T <: NfPoly
 	if parent(char1) != parent(char2)
 		throw(DomainError((parent(char1),parent(char2)), "Tables do not match."))

--- a/src/Ortho.jl
+++ b/src/Ortho.jl
@@ -158,15 +158,6 @@ function scalar(t::Table{T}, char1::Int64, char2::Int64) where T <: NfPoly
 	return scalar(t[char1], t[char2])
 end
 
-#TODO remove
-function scalar(t::Table{T}) where T <: NfPoly
-	for char1 in range(1, chartypes(t))
-		for char2 in range(1, char1)
-			println("$char1, $char2:\t", scalar(t,char1,char2))
-		end
-	end
-end
-
 
 @doc raw"""
     ortho2norm(t::Table{T}, class::Int64) where T <: NfPoly

--- a/src/Show.jl
+++ b/src/Show.jl
@@ -240,9 +240,10 @@ function status(t::Table)
 end
 
 @doc raw"""
-    printinfotab(io::IO, t::Table)
+    printinfotab([io::IO], t::Table)
 
-Print metadata of `t` in the latex format to `io` where `io` is optional.
+Print to `io` (or to the default output stream `stdout` if `io` is not given)
+metadata of `t` in LaTeX format.
 
 This usually includes the time the table was first computed.
 """
@@ -371,9 +372,10 @@ function nrclasses(t::SimpleCharTable, class::Int64)
 end
 
 @doc raw"""
-    printcharparam(io::IO, t::CharTable, char::Union{Int64, Nothing}=nothing)
+    printcharparam([io::IO], t::CharTable, char::Union{Int64, Nothing}=nothing)
 
-Print the parameters of the character type `char` of the table `t` to `io` where `io` is optional.
+Print to `io` (or to the default output stream `stdout` if `io` is not given)
+the parameters of the character type `char` of the table `t`.
 
 This includes the parameter names, ranges and exceptions. Leaving `char` unspecified will print the parameters of all character types.
 
@@ -405,9 +407,10 @@ end
 printcharparam(t::CharTable, char::Union{Int64, Nothing}=nothing) = printcharparam(Base.stdout, t, char)
 
 @doc raw"""
-    printclassparam(io::IO, t::CharTable, class::Union{Int64, Nothing}=nothing)
+    printclassparam([io::IO], t::CharTable, class::Union{Int64, Nothing}=nothing)
 
-Print the parameters of the class type `class` of the table `t` to `io` where `io` is optional.
+Print to `io` (or to the default output stream `stdout` if `io` is not given)
+the parameters of the class type `class` of the table `t`.
 
 This includes the parameter names, ranges and exceptions. Leaving `class` unspecified will print the parameters of all character types.
 
@@ -439,9 +442,10 @@ end
 printclassparam(t::CharTable, class::Union{Int64, Nothing}=nothing) = printclassparam(Base.stdout, t, class)
 
 @doc raw"""
-    printinfochar(io::IO, t::Table, char::Union{Int64, Nothing}=nothing)
+    printinfochar([io::IO], t::Table, char::Union{Int64, Nothing}=nothing)
 
-Print the infolists of the character type `char` of the table `t` to `io` where `io` is optional.
+Print to `io` (or to the default output stream `stdout` if `io` is not given)
+the infolists of the character type `char` of the table `t`.
 
 Leaving `char` unspecified will print the infolists of all character types.
 
@@ -474,9 +478,10 @@ end
 printinfochar(t::Table, char::Union{Int64, Nothing}=nothing) = printinfochar(Base.stdout, t, char)
 
 @doc raw"""
-    printinfoclass(io::IO, t::Table, class::Union{Int64, Nothing}=nothing)
+    printinfoclass([io::IO], t::Table, class::Union{Int64, Nothing}=nothing)
 
-Print the infolists of the class type `class` of the table `t` to `io` where `io` is optional.
+Print to `io` (or to the default output stream `stdout` if `io` is not given)
+the infolists of the class type `class` of the table `t`.
 
 Leaving `class` unspecified will print the infolists of all class types.
 
@@ -509,9 +514,10 @@ end
 printinfoclass(t::Table, class::Union{Int64, Nothing}=nothing) = printinfoclass(Base.stdout, t, class)
 
 @doc raw"""
-    printval(io::IO, t::Table; char::Union{Int64, Nothing}=nothing, class::Union{Int64, Nothing}=nothing)
+    printval([io::IO], t::Table; char::Union{Int64, Nothing}=nothing, class::Union{Int64, Nothing}=nothing)
 
-Print the values of the char type `char` and the class type `class` of the table `t` to `io` where `io` is optional.
+Print to `io` (or to the default output stream `stdout` if `io` is not given)
+the values of the char type `char` and the class type `class` of the table `t`.
 
 Leaving `class` unspecified will print the values of all class types at `char`.
 Leaving both unspecified will print all values of t


### PR DESCRIPTION
- **Restore 'missing' scalar docstring**
- **Add some doctest examples**
- **Remove scalar(t::Table{T}) method**
- **Align docstring involving optional io::IO args with Julia docs**
