### PR TITLE
Add bibliography to the manual

### DIFF
--- a/.bibtoolrsc
+++ b/.bibtoolrsc
@@ -1,7 +1,9 @@
 # This is a config file for bibtool, see
 #    http://www.gerd-neugebauer.de/software/TeX/BibTool/en/
 # To use it, invoke bibtool as follows:
-#   bibtool docs/oscar_references.bib -o docs/oscar_references.bib
+#   bibtool docs/src/refs.bib -o docs/src/refs.bib
+#
+# This file was copied from https://github.com/oscar-system/Oscar.jl version 1.1.0
 
 sort = on
 

--- a/.bibtoolrsc
+++ b/.bibtoolrsc
@@ -1,0 +1,84 @@
+# This is a config file for bibtool, see
+#    http://www.gerd-neugebauer.de/software/TeX/BibTool/en/
+# To use it, invoke bibtool as follows:
+#   bibtool docs/oscar_references.bib -o docs/oscar_references.bib
+
+sort = on
+
+# sort order for fields
+sort.order{* =
+    bibkey
+    author
+    title
+    editor
+    booktitle
+    mrnumber
+    zbl
+    journal
+    fjournal
+    series
+    volume
+    number
+    note
+    howpublished
+    address
+    organization
+    publisher
+    edition
+    pages
+    year
+    month
+    doi
+    url
+}
+
+print.align.key = 0
+print.line.length = 120
+preserve.key.case = on
+sort.cased = off
+print.use.tab = off
+
+delete.field = { hal_id }
+delete.field = { hal_version }
+delete.field = { isbn }
+delete.field = { issn }
+delete.field = { keywords }
+delete.field = { mrclass }
+delete.field = { mrreviewer }
+delete.field = { msc2010 }
+
+fmt.name.name = { }
+fmt.inter.name = { x }
+
+key.format =
+{
+    %s(bibkey)
+ #
+    %.1#n(author)
+    { %1.3n(author) }
+    { %2d(year) }
+ #
+    { %+8.1n(author) }
+    { %2d(year) }
+}
+
+# Enforce "{...}" around fields
+rewrite.rule {"^\"\([^#]*\)\"$" "{\1}"}
+rewrite.rule {"^ *\([0-9]*\) *$" "{\1}"}
+
+# Remove empty fields
+rewrite.rule {"^{ *}$"}
+
+# Unify page range separator
+rewrite.rule {pages "\([0-9]+\) *\(-\|---\|–\) *\([0-9]+\)" "\1--\3"}
+
+# Check that 1800<=year<=2029
+check.rule { year "^[\"{]1[89][0-9][0-9][\"}]$" }
+check.rule { year "^[\"{]20[0-2][0-9][\"}]$" }
+check.error.rule { year "" "\@ \$: Year has to be a suitable number" }
+
+# Check that the doi field is not a URL
+check.error.rule { doi "\://" "\@ \$: doi field should not be a URL" }
+
+# Check that the url field is not a DOI
+check.error.rule { url "doi\.org/" "\@ \$: url field should not contain a doi. Use the doi field instead" }

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,11 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 GenericCharacterTables = "fdcc7804-6c20-4e83-8118-baad6b7d05b7"
 Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 
 [compat]
-Documenter = "1"
-Oscar = "0.14, 1.0"
+Documenter = "1.1"
+DocumenterCitations = "~1.3.1"
+Oscar = "1.0"
 julia = "1.6"

--- a/docs/citation_style.jl
+++ b/docs/citation_style.jl
@@ -1,0 +1,38 @@
+#
+# This file is included by docs/make_work.jl to define the custom citation style `oscar_style`.
+#
+# It is heavily based upon
+# https://juliadocs.org/DocumenterCitations.jl/v1.0.0/gallery/#Custom-style:-Citation-key-labels
+#
+
+import DocumenterCitations
+
+const oscar_style = :oscar
+
+# The long reference string in the bibliography
+function DocumenterCitations.format_bibliography_reference(style::Val{oscar_style}, entry)
+  return DocumenterCitations.format_labeled_bibliography_reference(style, entry)
+end
+
+# The label in the bibliography
+function DocumenterCitations.format_bibliography_label(::Val{oscar_style}, entry, citations)
+  return "[$(entry.id)]"
+end
+
+function DocumenterCitations.citation_label(style::Val{oscar_style}, entry, citations; _...)
+  return entry.id
+end
+
+# The order of entries in the bibliography
+DocumenterCitations.bib_sorting(::Val{oscar_style}) = :key  # sort by citation key
+
+# The type of html tag to use for the bibliography
+DocumenterCitations.bib_html_list_style(::Val{oscar_style}) = :dl
+
+function DocumenterCitations.format_citation(
+  style::Val{oscar_style}, cit, entries, citations
+)
+  # The only difference compared to `:alpha` is the citation label, which is
+  # picked up automatically by redefining `citation_label` above.
+  return DocumenterCitations.format_labeled_citation(style, cit, entries, citations)
+end

--- a/docs/citation_style.jl
+++ b/docs/citation_style.jl
@@ -1,3 +1,5 @@
+# Copyright (c) 2023 Lars Göttgens, The OSCAR Development Team
+# This file was copied from https://github.com/oscar-system/Oscar.jl version 1.1.0
 #
 # This file is included by docs/make_work.jl to define the custom citation style `oscar_style`.
 #

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,18 +1,34 @@
-using Documenter, GenericCharacterTables
+using Documenter
+using DocumenterCitations
+using GenericCharacterTables
+
+include("citation_style.jl")
 
 DocMeta.setdocmeta!(GenericCharacterTables, :DocTestSetup, :(using GenericCharacterTables, Oscar); recursive=true)
 
+bib = CitationBibliography(
+    joinpath(@__DIR__, "src", "refs.bib");
+    style=oscar_style,
+)
+
 makedocs(
 	sitename="GenericCharacterTables.jl",
-	format=Documenter.HTML(prettyurls=get(ENV, "CI", "false") == "true"),
+	format=Documenter.HTML(
+	    prettyurls=get(ENV, "CI", "false") == "true",
+        assets=[
+            "assets/citations.css",
+        ],
+    ),
 	doctest = true,
 	pages=[
 		"index.md",
 		"showinfo.md",
 		"calculations.md",
 		"modify.md",
-		"unexported.md"
-	]
+		"unexported.md",
+		"references.md",
+	],
+	plugins=[bib],
 )
 
 deploydocs(

--- a/docs/src/assets/citations.css
+++ b/docs/src/assets/citations.css
@@ -1,0 +1,17 @@
+.citation dl {
+  display: grid;
+  grid-template-columns: max-content auto; }
+.citation dt {
+  grid-column-start: 1; }
+.citation dd {
+  grid-column-start: 2;
+  margin-bottom: 0.75em; }
+.citation ul {
+ padding: 0 0 2.25em 0;
+ margin: 0;
+ list-style: none !important;}
+.citation ul li {
+ text-indent: -2.25em;
+ margin: 0.33em 0.5em 0.5em 2.25em;}
+.citation ol li {
+ padding-left:0.75em;}

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,6 +15,23 @@ It is written in [Julia](https://julialang.org/) and depends on
 [Nemo](https://nemocas.github.io/Nemo.jl/stable/) and therefore on
 [AbstractAlgebra](https://nemocas.github.io/AbstractAlgebra.jl/stable/).
 
+
+For the mathematical background, consider that there are many interesting
+*families* of finite groups. For example, the matrix groups
+$\mathrm{GL}_n(\mathbb{F}_q)$ or $\mathrm{SL}_n(\mathbb{F}_q)$, for $n>1$ and
+$q$ a prime power. These groups have many properties in common. It turns out
+that for a fixed rank (say $n=2$) it is possible to parametrize the conjugacy
+classes and irreducible characters of these group in terms of $q$, and to
+write this down into a so-called *generic character table*. This was first
+done by Schur for $\mathrm{SL}_2(\mathbb{F}_q)$.
+
+This package provides code to interact with such generic character tables,
+and also includes many such tables.
+The code in this package is based on Maple code included in the CHEVIE project.
+
+For more details about the mathematical background, see [GHLMP96](@cite).
+
+
 ## Loading tables
 
 Before doing anything you need to load a table first. GenericCharacterTables comes with a variety of precomputed tables.

--- a/docs/src/references.md
+++ b/docs/src/references.md
@@ -1,0 +1,4 @@
+# References
+```@bibliography
+*
+```

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,0 +1,26 @@
+
+@Article{GHLMP96,
+  author        = {Geck, Meinolf and Hiss, Gerhard and Lübeck, Frank and Malle, Gunter and Pfeiffer, Götz},
+  title         = {C{HEVIE}---a system for computing and processing generic character tables},
+  mrnumber      = {1486215},
+  journal       = {Appl. Algebra Engrg. Comm. Comput.},
+  fjournal      = {Applicable Algebra in Engineering, Communication and Computing},
+  volume        = {7},
+  number        = {3},
+  note          = {Computational methods in Lie theory (Essen, 1994)},
+  pages         = {175--210},
+  year          = {1996},
+  doi           = {10.1007/BF01190329}
+}
+
+@Book{OSCAR,
+  bibkey        = {OSCAR},
+  title         = {The {C}omputer {A}lgebra {S}ystem {OSCAR}: {A}lgorithms and {E}xamples},
+  editor        = {Decker, Wolfram and Eder, Christian and Fieker, Claus and Horn, Max and Joswig, Michael},
+  series        = {Algorithms and {C}omputation in {M}athematics},
+  volume        = {32},
+  publisher     = {Springer},
+  year          = {2024},
+  month         = {8},
+  url           = {https://link.springer.com/book/9783031621260}
+}

--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -1,7 +1,7 @@
 
 @Article{GHLMP96,
   author        = {Geck, Meinolf and Hiss, Gerhard and Lübeck, Frank and Malle, Gunter and Pfeiffer, Götz},
-  title         = {C{HEVIE}---a system for computing and processing generic character tables},
+  title         = {CHEVIE---a system for computing and processing generic character tables},
   mrnumber      = {1486215},
   journal       = {Appl. Algebra Engrg. Comm. Comput.},
   fjournal      = {Applicable Algebra in Engineering, Communication and Computing},
@@ -15,9 +15,9 @@
 
 @Book{OSCAR,
   bibkey        = {OSCAR},
-  title         = {The {C}omputer {A}lgebra {S}ystem {OSCAR}: {A}lgorithms and {E}xamples},
+  title         = {The Computer Algebra System OSCAR: Algorithms and Examples},
   editor        = {Decker, Wolfram and Eder, Christian and Fieker, Claus and Horn, Max and Joswig, Michael},
-  series        = {Algorithms and {C}omputation in {M}athematics},
+  series        = {Algorithms and Computation in Mathematics},
   volume        = {32},
   publisher     = {Springer},
   year          = {2024},

--- a/etc/format_bib
+++ b/etc/format_bib
@@ -1,0 +1,2 @@
+#!/bin/sh
+bibtool docs/src/refs.bib -o docs/src/refs.bib

--- a/etc/format_bib
+++ b/etc/format_bib
@@ -1,2 +1,0 @@
-#!/bin/sh
-bibtool docs/src/refs.bib -o docs/src/refs.bib


### PR DESCRIPTION
The custom citation style is copied from OSCAR and basically ensures that the exact citation keys are used that we prescribe in the .bib file.

Citation keys are instead managed via `bibtool`. To this end, the helper script `etc/format_bib` can be run from the root directory of this package to reformat `docs/src/refs.bib` in a consistent way. If a custom citation key is desired, one can add a `bibkey` field.