### PR TITLE
added `GenericCycloFrac` using `GenericCyclo`

### DIFF
--- a/src/GenericCharacterTables.jl
+++ b/src/GenericCharacterTables.jl
@@ -23,6 +23,7 @@ const FracPoly{T} = Generic.UnivPoly{Generic.FracFieldElem{T}} where T
 const NfPoly = Union{PolyRingElem{QQFieldElem}, PolyRingElem{AbsSimpleNumFieldElem}}
 
 include("GenericCyclotomics.jl")
+include("GenericCyclotomicFractions.jl")
 include("Parameter.jl")
 include("Arith.jl")
 include("CharTable.jl")

--- a/src/GenericCyclotomicFractions.jl
+++ b/src/GenericCyclotomicFractions.jl
@@ -1,0 +1,190 @@
+import Oscar.AbstractAlgebra: evaluate
+
+import Base: show, isone, iszero, one, zero, conj, inv, +, -, *, //, ==
+
+# This models fractions of sums of cyclotomics.
+# The simplification is currently only very basic.
+# According to the original implementation
+# more advanced simplifications seem to have
+# no positive effect on the performance.
+struct GenericCycloFrac
+	numerator::GenericCyclo
+	denominator::GenericCyclo
+	exceptions::Set{UPolyFrac}  # The element may only be evaluated if none of the exceptions evaluates to an integer.
+	function GenericCycloFrac(numerator::GenericCyclo, denominator::GenericCyclo, exceptions::Set{UPolyFrac}; simplify::Bool=true)
+		check_parent(numerator, denominator)
+		if simplify
+			if iszero(numerator)
+				return new(numerator, one(denominator), exceptions)
+			elseif numerator == denominator
+				o=one(denominator)
+				return new(o, o, exceptions)
+			end
+		end
+		return new(numerator, denominator, exceptions)
+	end
+end
+
+function add_exception!(a::GenericCycloFrac, exception::UPolyFrac)
+	push!(a.exceptions, exception)
+end
+
+@doc raw"""
+    shrink(a::GenericCycloFrac{<:NfPoly})
+
+Remove exceptions from `a` that follow from the others. And try to simplify the representation of `a`.
+"""
+function shrink(a::GenericCycloFrac)  # TODO Move this to the constructor of GenericCycloFrac?
+	new_numerator=a.numerator
+	new_denominator=a.denominator
+	if isone(length(new_numerator.f)) && isone(length(new_denominator.f))
+		numerator_argument,numerator_modulus=collect(new_numerator.f)[1]
+		denominator_argument,denominator_modulus=collect(new_denominator.f)[1]
+		if numerator_argument == denominator_argument
+			b=numerator_modulus//denominator_modulus
+			o=one(new_numerator)
+			new_numerator=o*numerator(b)
+			new_denominator=o*denominator(b)
+		end
+	end
+	new_exceptions = Set{UPolyFrac}()
+	for exception1 in a.exceptions
+		needed = true
+		for exception2 in setdiff(a.exceptions,[exception1])
+			quotient=exception2//exception1
+			if isone(denominator(quotient))
+				if is_constant(numerator(quotient))
+					c=constant_coefficient(numerator(quotient))
+					if isone(denominator(c))
+						# In this case exception2 is an integer multiple of exception1, so if exception1 evaluates to an
+						# integer exception2 does as well. Hence, it suffices to track exception2 and we can discard
+						# exception1.
+						needed = false
+						break
+					end
+				end
+			end
+		end
+		if needed
+			# TODO test if exception1 is a rational number and apply normal_form to the "whole" part of exception1, similar to the
+			# simplification of GenericCyclotomic.
+			push!(new_exceptions,exception1)
+		end
+	end
+	return GenericCycloFrac(new_numerator, new_denominator, new_exceptions, simplify=false)
+end
+
+function show(io::IO, x::GenericCycloFrac)
+	io=pretty(io)
+	if isone(x.denominator)
+		print(io, "$(x.numerator)")
+	else
+		if isone(length(x.numerator.f))
+			print(io, "$(x.numerator)//")
+		else
+			print(io, "($(x.numerator))//")
+		end
+		if isone(length(x.denominator.f))
+			argument,modulus=collect(x.denominator.f)[1]
+			if iszero(argument) && (is_monomial(modulus) || is_constant(modulus))
+				print(io, "$(x.denominator)")
+			else
+				print(io, "($(x.denominator))")
+			end
+		else
+			print(io, "($(x.denominator))")
+		end
+	end
+	if !isempty(x.exceptions)
+		print(io, "\nWith exceptions:", Indent())
+		for exception in x.exceptions
+			if isone(denominator(exception))
+				print(io, "\n$(numerator(exception)) ∈ ℤ")
+			else
+				print(io, "\n$(numerator(exception)) ∈ ($(denominator(exception)))ℤ")
+			end
+		end
+		print(io, Dedent())
+	end
+end
+
+isone(x::GenericCycloFrac) = isone(x.numerator) && isone(x.denominator)
+
+@doc raw"""
+    iszero(x::GenericCycloFrac; ignore_exceptions::Bool=false)
+
+Return if `x` is zero. If `ignore_exceptions` is true then the exceptions of `x` will not be considered.
+"""
+function iszero(x::GenericCycloFrac; ignore_exceptions::Bool=false)
+	if ignore_exceptions
+		return iszero(x.numerator)
+	end
+	return iszero(x.numerator) && isempty(x.exceptions)
+end
+
+# Unary operations
+
+function one(x::GenericCycloFrac)
+	o=one(x.numerator)
+	return GenericCycloFrac(o, o, x.exceptions, simplify=false)
+end
+
+zero(x::GenericCycloFrac) = GenericCycloFrac(zero(x.numerator), one(x.denominator), x.exceptions, simplify=false)  # TODO construct a generic zero here?
+
+conj(x::GenericCycloFrac) = GenericCycloFrac(conj(x.numerator), conj(x.denominator), x.exceptions, simplify=false)
+
+inv(x::GenericCycloFrac) = GenericCycloFrac(x.denominator, x.numerator, x.exceptions, simplify=false)
+
+-(x::GenericCycloFrac) = GenericCycloFrac(-x.numerator, x.denominator, x.exceptions, simplify=false)
+
+# Binary operations
+
+*(factor::RingElement, x::GenericCycloFrac) = iszero(factor) ? zero(x) : GenericCycloFrac(factor*x.numerator, x.denominator, x.exceptions, simplify=false)
+*(x::GenericCycloFrac, factor::RingElement) = factor*x
+
+(==)(x::GenericCycloFrac, y::GenericCycloFrac) = iszero((x-y).numerator)
+
+function *(x::GenericCycloFrac, y::GenericCycloFrac)
+	numerator=x.numerator*y.numerator
+	denominator=x.denominator*y.denominator
+	exceptions=union(x.exceptions, y.exceptions)
+	GenericCycloFrac(numerator, denominator, exceptions)
+end
+
+function +(x::GenericCycloFrac, y::GenericCycloFrac)
+	if x.denominator == y.denominator
+		return GenericCycloFrac(x.numerator+y.numerator, x.denominator, union(x.exceptions, y.exceptions), simplify=!isone(x.denominator))
+	else
+		numerator=x.numerator*y.denominator+y.numerator*x.denominator
+		denominator=x.denominator*y.denominator
+		exceptions=union(x.exceptions, y.exceptions)
+		return GenericCycloFrac(numerator, denominator, exceptions)
+	end
+end
+
++(x::GenericCycloFrac, y::RingElement) = GenericCycloFrac(x.numerator+y*x.denominator, x.denominator, x.exceptions)
+
++(x::RingElement, y::GenericCycloFrac) = y+x
+
+-(x::GenericCycloFrac, y::GenericCycloFrac) = x+(-y)
+
+-(x::GenericCycloFrac, y::RingElement) = x+(-y)
+
+-(x::RingElement, y::GenericCycloFrac) = x+(-y)
+
+//(x::GenericCycloFrac, y::GenericCycloFrac) = x*GenericCycloFrac(y.denominator, y.numerator, y.exceptions, simplify=false)
+
+//(x::GenericCycloFrac, y::RingElement) = GenericCycloFrac(x.numerator, x.denominator*y, x.exceptions, simplify=false)
+
+//(x::RingElement, y::GenericCycloFrac) = x*inv(y)
+
+//(x::GenericCyclo, y::GenericCyclo) = GenericCycloFrac(x, y, Set{UPolyFrac}())
+
+# evaluate
+
+function evaluate(x::GenericCycloFrac, vars::Vector{Int64}, vals::Vector{<:RingElement})
+	numerator=evaluate(x.numerator, vars, vals)
+	denominator=evaluate(x.denominator, vars, vals)
+	exceptions=evaluate.(x.exceptions, Ref(vars), Ref(vals))
+	return GenericCycloFrac(numerator, denominator, Set{UPolyFrac}(exceptions))
+end

--- a/src/GenericCyclotomicFractions.jl
+++ b/src/GenericCyclotomicFractions.jl
@@ -139,7 +139,7 @@ inv(x::GenericCycloFrac) = GenericCycloFrac(x.denominator, x.numerator, x.except
 
 # Binary operations
 
-*(factor::RingElement, x::GenericCycloFrac) = iszero(factor) ? zero(x) : GenericCycloFrac(factor*x.numerator, x.denominator, x.exceptions, simplify=false)
+*(factor::RingElement, x::GenericCycloFrac) = iszero(factor) ? zero(x) : GenericCycloFrac(factor*x.numerator, x.denominator, x.exceptions)
 *(x::GenericCycloFrac, factor::RingElement) = factor*x
 
 (==)(x::GenericCycloFrac, y::GenericCycloFrac) = iszero((x-y).numerator)  # TODO compare exceptions?

--- a/src/GenericCyclotomicFractions.jl
+++ b/src/GenericCyclotomicFractions.jl
@@ -142,7 +142,11 @@ inv(x::GenericCycloFrac) = GenericCycloFrac(x.denominator, x.numerator, x.except
 *(factor::RingElement, x::GenericCycloFrac) = iszero(factor) ? zero(x) : GenericCycloFrac(factor*x.numerator, x.denominator, x.exceptions, simplify=false)
 *(x::GenericCycloFrac, factor::RingElement) = factor*x
 
-(==)(x::GenericCycloFrac, y::GenericCycloFrac) = iszero((x-y).numerator)
+(==)(x::GenericCycloFrac, y::GenericCycloFrac) = iszero((x-y).numerator)  # TODO compare exceptions?
+
+(==)(x::GenericCycloFrac, y::RingElement) = iszero((x-y).numerator)  # TODO compare exceptions?
+
+(==)(x::RingElement, y::GenericCycloFrac) = y==x
 
 function *(x::GenericCycloFrac, y::GenericCycloFrac)
 	numerator=x.numerator*y.numerator

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,52 @@ end
 
 test_Ring_interface(S)
 
+@testset "GenericCyclo" begin
+	R = universal_polynomial_ring(QQ)
+	q, i, j = gens(R, [:q, :i, :j])
+	S = generic_cyclotomic_ring(R)
+
+	a=S(Dict(1//(q-1)*i+2//(q-1)*j+q^2//(q+1)*i => R(1)))
+	b=S(Dict(2*q//(q^2-1)*i+2//(q-1)*j => R(1)))
+	@test a==b
+
+	c=S(Dict(1//q*j => R(1)))
+	@test (a+c)==(c+a)
+	@test iszero(-c+c)
+
+	@test a-1+S(Dict(0//R(1) => R(1)))==a
+	@test a*1==a
+	@test 2*a-a==a
+	@test 2*a+a==3*a
+
+	@test isone(a//a)
+	@test isone((a//c)*inv(a//c))
+
+	d=S(Dict(1//R(3) => R(-1)))
+	@test isone(d+conj(d))
+
+	e=evaluate(a, [1, 2], [2, 6//5])
+	f=S(Dict(1//R(5) => R(1)))^3
+	@test e==f
+
+	g=evaluate(a//f, [1, 2], [2, 6//5])
+	@test isone(g)
+
+	@test iszero(S(0)//S(2))
+	@test iszero(zero(S(1)//S(1)))
+	@test isone(one(S(0)//S(1)))
+	@test iszero(1//S(1)-1)
+	@test iszero(1-S(1)//1)
+	@test 1//(S(1)//S(1)) == (S(1)//S(1))//1
+	@test isone((S(1)//S(2))//(S(1)//S(2)))
+	@test iszero((S(1)//S(2))-(S(1)//S(2)))
+	@test isone((S(1)//S(2))+(S(1)//S(2)))
+	@test (S(1)//S(3))+(S(1)//S(6)) == (S(1)//S(2))
+	@test isone((S(1)//S(2))*2)
+
+	@test conj(a//c) == conj(a)//conj(c)
+end
+
 @testset "Cyclotomic" begin
 	R, q = polynomial_ring(QQ, "q")
 	Q = fraction_field(R)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,7 +55,8 @@ test_Ring_interface(S)
 	@test isone((S(1)//S(2))//(S(1)//S(2)))
 	@test iszero((S(1)//S(2))-(S(1)//S(2)))
 	@test isone((S(1)//S(2))+(S(1)//S(2)))
-	@test (S(1)//S(3))+(S(1)//S(6)) == (S(1)//S(2))
+	@test (S(1)//S(3))+(S(1)//S(6)) == 1//2
+	@test 1//3+1//6 == S(1)//S(2)
 	@test isone((S(1)//S(2))*2)
 
 	@test conj(a//c) == conj(a)//conj(c)


### PR DESCRIPTION
This is the first follow up for #82. It introduces `GenericCycloFrac` which will replace `CycloFrac`. The code is partially copied from `Arith.jl` (which will be removed eventually). It is now independent of `ParameterException` because I like to remove this as well and I needed to somehow use `UPolyFrac` instead of `FracPoly` to model the exceptions to be compatible with `GenericCyclo`. This has the nice side effect that the `shrink` method for `GenericCycloFrac` should now be easier to understand and hopefully also easier to improve (#54).

The new code still lacks some tests.