### PR TITLE
Remmove print_decomposition

### DIFF
--- a/src/Show.jl
+++ b/src/Show.jl
@@ -567,23 +567,6 @@ end
 
 printval(t::Table; kwarg...) = printval(stdout, t; kwarg...)
 
-# TODO: document this (and/or replace it by something better)
-function print_decomposition(io::IO, t::CharTable, chi::AbstractGenericCharacter)
-	io = pretty(io)
-	print(io, "Decomposing character chi:", Indent())
-	for i in 1:irrchartypes(t)
-		println(io)
-		s = scalar_product(t[i], chi)
-		print(io, "<$i,chi> = ", Indent(), s, Dedent())
-	end
-	print(io, Dedent())
-end
-
-print_decomposition(io::IO, t::CharTable, char::Int) = print_decomposition(io, t, t[char])
-print_decomposition(t::CharTable, char::AbstractGenericCharacter) = print_decomposition(stdout, t, char)
-print_decomposition(t::CharTable, char::Int) = print_decomposition(stdout, t, char)
-export print_decomposition
-
 @doc raw"""
     nrparams(t::CharTable)
 


### PR DESCRIPTION
It was added for the book, but the book won't use it anymore
