### PR TITLE
CI: disable tests against Julia nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
           - '1.9'
           - '1.10'
           - '~1.11.0-0'
-          - 'nightly'
+          #- 'nightly'  # disabled due to https://github.com/JuliaLang/julia/issues/55006
         os:
           - ubuntu-latest
         #include:


### PR DESCRIPTION
It is not helpful to always have these failing for reasons beyond our control. For background information, see here: <https://github.com/JuliaLang/julia/issues/55006>
