### PR TITLE
Fix `lincomb`

### DIFF
--- a/src/GenericCharacter.jl
+++ b/src/GenericCharacter.jl
@@ -197,7 +197,7 @@ function lincomb(coeffs::Vector{Int64}, chars::Vector{<:GenericCharacter})
 	if missing_var_batches > 0
 		vars=map(x -> String(x), symbols(S)[2:(nrparams(t)+1)]).*"l"
 		for i in 1:missing_var_batches
-			gens(S, vars.*string(i))
+			gens(S, vars.*string(extra_var_batches+i))
 		end
 	end
 	degrees=map(x -> x.degree, chars)

--- a/src/Shifts.jl
+++ b/src/Shifts.jl
@@ -14,6 +14,9 @@ end
 function var_shift(a::UPoly, vars::Vector{Int64}, step_size::Int64, steps::Int64)
 	return evaluate(a, vars, get_shift_mask(parent(a), vars, step_size, steps))
 end
+function var_shift(a::UPolyFrac, vars::Vector{Int64}, step_size::Int64, steps::Int64)
+	return evaluate(a, vars, get_shift_mask(parent(numerator(a)), vars, step_size, steps))
+end
 function var_shift(a::GenericCyclo, vars::Vector{Int64}, step_size::Int64, steps::Int64)
 	return evaluate(a, vars, get_shift_mask(base_ring(parent(a)), vars, step_size, steps))
 end


### PR DESCRIPTION
```
julia> T = genchartab("SL3.n1");

julia> lincomb([1,1], [T[2], T[6]])
Generic character of SL3.n1
  with parameters 
    nl2 ∈ {1,…, q - 1}, ml2 ∈ {1,…, q - 1} except -ml2 + nl2 ∈ (q - 1)ℤ
  of degree q^3 + 3*q^2 + 3*q + 1
  with values
    q^3 + 3*q^2 + 3*q + 1
    3*q + 1
    1
    (q + 1)*exp(2π𝑖((a*ml2 + a*nl2)//(q - 1))) + (q + 1)*exp(2π𝑖((a*ml2 - 2*a*nl2)//(q - 1))) + q + 1 + (q + 1)*exp(2π𝑖((-2*a*ml2 + a*nl2)//(q - 1)))
    exp(2π𝑖((a*ml2 + a*nl2)//(q - 1))) + exp(2π𝑖((a*ml2 - 2*a*nl2)//(q - 1))) + 1 + exp(2π𝑖((-2*a*ml2 + a*nl2)//(q - 1)))
    exp(2π𝑖((-a*nl2 + b*ml2 - b*nl2)//(q - 1))) + exp(2π𝑖((-a*ml2 + a*nl2 - b*ml2)//(q - 1))) + exp(2π𝑖((a*ml2 + b*nl2)//(q - 1))) + exp(2π𝑖((-a*ml2 - b*ml2 + b*nl2)//(q - 1))) + exp(2π𝑖((a*ml2 - a*nl2 - b*nl2)//(q - 1))) + 2 + exp(2π𝑖((a*nl2 + b*ml
    2)//(q - 1)))
    0
    -1

julia> lincomb([1,2,2],[T[1],T[2],T[3]])
Generic character of SL3.n1
  of degree 2*q^3 + 2*q^2 + 2*q + 1
  with values
    2*q^3 + 2*q^2 + 2*q + 1
    2*q + 1
    1
    4*q + 3
    3
    7
    -1
    1

```

Fixes: #189