### PR TITLE
HACK: add faster arithmetic for UnivPoly and ZZRingElem

### DIFF
--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -413,6 +413,25 @@ function (R::GenericCycloRing)(x::RingElement; exponent::UPolyFrac)
 	return R(Dict(exponent => base_ring(R)(x)))
 end
 
+# TODO: move the following methods to Nemo
+function *(p::Generic.UnivPoly{T, U}, n::ZZRingElem) where {T, U}
+   S = parent(p)
+   return Generic.UnivPoly{T, U}(p.p*n, S)
+end
+
+*(n::ZZRingElem, p::Generic.UnivPoly) = p*n
+
+function -(p::Generic.UnivPoly{T, U}, n::ZZRingElem) where {T, U}
+   S = parent(p)
+   return Generic.UnivPoly{T, U}(p.p-n, S)
+end
+
+function -(n::ZZRingElem, p::Generic.UnivPoly{T, U}) where {T, U}
+   S = parent(p)
+   return Generic.UnivPoly{T, U}(n-p.p, S)
+end
+
+
 function (R::GenericCycloRing)(f::Dict{UPolyFrac, UPoly}; simplify::Bool=true)  # TODO check parent rings?
 	if !simplify
 		return GenericCyclo(f, R)


### PR DESCRIPTION
This is not meant to be merged, just serve as a reminder: arithmetic for UnivPoly could be quite a bit more efficient. The methods added here help concrete computations in the method `(R::GenericCycloRing)(f::Dict{UPolyFrac, UPoly}; simplify::Bool=true)`. 

But they are not going far enough and are incomplete. Someone should patch AA (and perhaps Nemo) to add...
- `add!`, `sub!`, `mul!` methods in AA looking like this:
  ```julia
  function add!(a::UnivPoly{T}, b::UnivPoly{T}, c::Any) where {T <: RingElement}
     a.p = add!(a.p, b.p, c)
     return a
  end
  ```
  (One may argue whether `c` should be restricted to e.g. `RingElement` but I think for this kind of fallback it has no advantage?)
- we should also add `addmul!` (there also in the variant which takes three `UnivPoly`)
- then of course improved +, -, * etc. methods possibly based on the new `add!`, `sub!`, `mul!` methods