### PR TITLE
Stop importing `get_cached!`

### DIFF
--- a/src/Imports.jl
+++ b/src/Imports.jl
@@ -47,7 +47,6 @@ import Oscar:
 	elem_type,
 	evaluate,
 	expressify,
-	get_cached!,
 	Indent,
 	is_domain_type,
 	isequal,


### PR DESCRIPTION
This import caused a warning. As we don't need `get_chached!`, I think we can just stop importing it.