### PR TITLE
Add an `invokelatest` that may be required in 1.12

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,7 +154,7 @@ end
     # skip tables containing only unipotent character types
     startswith(table, "uni") && continue
 
-    invokelatest() do
+    Base.invokelatest() do
       @test order(g) == sum(number_of_characters(c) * degree(c)^2 for c in g)
     end
   end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,6 +154,8 @@ end
     # skip tables containing only unipotent character types
     startswith(table, "uni") && continue
 
-    @test order(g) == sum(number_of_characters(c) * degree(c)^2 for c in g)
+    invokelatest() do
+      @test order(g) == sum(number_of_characters(c) * degree(c)^2 for c in g)
+    end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,6 +154,8 @@ end
     # skip tables containing only unipotent character types
     startswith(table, "uni") && continue
 
+    # Workaround that may be needed in Julia >= 1.12. Can be removed
+    # when we manage to remove the need for `eval` when loading tables.
     Base.invokelatest() do
       @test order(g) == sum(number_of_characters(c) * degree(c)^2 for c in g)
     end


### PR DESCRIPTION
This test currently relies on implicit world age increments at top level. We're re-evaluating where these go because julia is currently inconsistent about it in the interpreter, compiler and inference. To make sure this test keeps working on 1.12, add an explicit world age increment. See https://github.com/JuliaLang/julia/pull/56509.