### PR TITLE
Make `GenericCycloRing` immutable

### DIFF
--- a/src/Types.jl
+++ b/src/Types.jl
@@ -27,7 +27,7 @@ Generic cyclotomic ring
   dependent on q
 ```
 """
-mutable struct GenericCycloRing <: Ring
+struct GenericCycloRing <: Ring
   base_ring::UPolyRing
   congruence::Union{Tuple{ZZRingElem,ZZRingElem},Nothing}
 end


### PR DESCRIPTION
As discussed previously `GenericCycloRing` shouldn't be mutable.