### PR TITLE
Don't recompute congruence substitutions

### DIFF
--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -365,13 +365,6 @@ function (R::GenericCycloRing)(f::Dict{UPolyFrac,UPoly}; simplify::Bool=true)  #
     return GenericCyclo(f, R)
   end
 
-  # congruence preparation
-  if R.congruence !== nothing
-    q = gen(base_ring(R), 1)
-    substitute = R.congruence[2] * q + R.congruence[1]
-    substitute_inv = (q - R.congruence[1]) * 1//R.congruence[2]
-  end
-
   # reduce numerators modulo denominators
   L = NTuple{4,UPoly}[]
   for (g, c) in f
@@ -381,8 +374,8 @@ function (R::GenericCycloRing)(f::Dict{UPolyFrac,UPoly}; simplify::Bool=true)  #
       else
         gp =
           evaluate(
-            numerator(g), [1], [substitute]
-          )//evaluate(denominator(g), [1], [substitute])
+            numerator(g), [1], [R.substitute]
+          )//evaluate(denominator(g), [1], [R.substitute])
       end
       a, r = divrem(numerator(gp), denominator(gp))
       push!(L, (c, denominator(gp), r, a))
@@ -430,8 +423,8 @@ function (R::GenericCycloRing)(f::Dict{UPolyFrac,UPoly}; simplify::Bool=true)  #
       else
         gp =
           evaluate(
-            numerator(g), [1], [substitute_inv]
-          )//evaluate(denominator(g), [1], [substitute_inv])
+            numerator(g), [1], [R.substitute_inv]
+          )//evaluate(denominator(g), [1], [R.substitute_inv])
       end
       if haskey(fp, gp)
         fp[gp] += cp * c
@@ -460,13 +453,11 @@ end
 
 # Parent constructor
 
-# TODO Maybe don't require at least one variable?
 function generic_cyclotomic_ring(
   R::UPolyRing;
   congruence::Union{Tuple{ZZRingElem,ZZRingElem},Nothing}=nothing,
   cached::Bool=true,
 )
-  length(gens(R)) < 1 && error("At least one free variable is needed")
   return GenericCycloRing(R, congruence)
 end
 

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -30,6 +30,23 @@ Generic cyclotomic ring
 struct GenericCycloRing <: Ring
   base_ring::UPolyRing
   congruence::Union{Tuple{ZZRingElem,ZZRingElem},Nothing}
+  substitute::UPoly
+  substitute_inv::UPoly
+  function GenericCycloRing(
+    R::UPolyRing,
+    congruence::Union{Tuple{ZZRingElem,ZZRingElem},Nothing},
+  )
+    # TODO Maybe don't require at least one variable?
+    length(gens(R)) < 1 && error("At least one free variable is needed")
+    if congruence == nothing
+      return new(R, congruence)
+    else
+      q = gen(R, 1)
+      substitute = congruence[2] * q + congruence[1]
+      substitute_inv = (q - congruence[1]) * 1//congruence[2]
+      return new(R, congruence, substitute, substitute_inv)
+    end
+  end
 end
 
 @doc raw"""


### PR DESCRIPTION
As discussed earlier we shouldn't recompute the substitutions used in the simplification of `GenericCyclo`. Apparently I've made it slower and increased the allocations when computing scalar products of tables with congruence as in #238 .
Before the patch with `SL3.1`:
` 25.557065 seconds (98.68 M allocations: 8.370 GiB, 11.97% gc time)`
And after the patch with `SL3.1`:
` 36.824178 seconds (111.61 M allocations: 10.982 GiB, 9.44% gc time)`

@fingolfin Do you see the problem here?