### PR TITLE
Use some unsave operators

### DIFF
--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -127,7 +127,7 @@ function normal_form(f::ZZUPoly, m::Int64)
     S_ik = rising_factorial(x_i, k)
     C_ik = coeff(f, [x_i], [k])
     c = normal_form(C_ik, reduction)
-    f -= (C_ik - c) * S_ik
+    submul!(f, C_ik - c, S_ik)
   end
   return f
 end
@@ -266,7 +266,7 @@ function *(x::GenericCyclo, y::GenericCyclo)
     for (key2, value2) in y.f
       key = key1 + key2
       if haskey(f, key)
-        f[key] += value1 * value2
+        addmul!(f[key], value1, value2)
       else
         f[key] = value1 * value2
       end
@@ -429,7 +429,7 @@ function (R::GenericCycloRing)(f::Dict{UPolyFrac,UPoly}; simplify::Bool=true)  #
         gp = evaluate(g, [1], [substitute_inv])
       end
       if haskey(fp, gp)
-        fp[gp] += cp * c
+        addmul!(fp[gp], cp, c)
       else
         fp[gp] = cp * c
       end


### PR DESCRIPTION
With the test for `3D4.0` from #238 current master performs like this:
```
julia> @time scalar_test(g)
 71.137125 seconds (233.27 M allocations: 24.491 GiB, 12.05% gc time)
```
And this PR:
```
julia> @time scalar_test(g)
 66.839489 seconds (231.88 M allocations: 24.387 GiB, 11.68% gc time)
```