### PR TITLE
Initial expressify test

### DIFF
--- a/docs/src/book.md
+++ b/docs/src/book.md
@@ -28,7 +28,7 @@ linear combinations over $\mathbb{Q}(q)$ of symbolic “roots of unity”
 depending on the parameters listed above.
 ```jldoctest book
 julia> T[4,4]
-(q + 1)*exp(2π𝑖((a*n)//(q - 1))) + exp(2π𝑖((-2*a*n)//(q - 1)))
+(q + 1)*exp(2π𝑖*(a*n)//(q - 1)) + exp(-2π𝑖*(2*a*n)//(q - 1))
 ```
 
 Denoting row 4 of the table by $\chi_4$, we note that is not a single
@@ -44,10 +44,10 @@ Generic character of SL3.n1
     q^2 + q + 1
     q + 1
     1
-    (q + 1)*exp(2π𝑖((a*n)//(q - 1))) + exp(2π𝑖((-2*a*n)//(q - 1)))
-    exp(2π𝑖((a*n)//(q - 1))) + exp(2π𝑖((-2*a*n)//(q - 1)))
-    exp(2π𝑖((a*n)//(q - 1))) + exp(2π𝑖((b*n)//(q - 1))) + exp(2π𝑖((-a*n - b*n)//(q - 1)))
-    exp(2π𝑖((a*n)//(q - 1)))
+    (q + 1)*exp(2π𝑖*(a*n)//(q - 1)) + exp(-2π𝑖*(2*a*n)//(q - 1))
+    exp(2π𝑖*(a*n)//(q - 1)) + exp(-2π𝑖*(2*a*n)//(q - 1))
+    exp(2π𝑖*(a*n)//(q - 1)) + exp(2π𝑖*(b*n)//(q - 1)) + exp(2π𝑖*(-a*n - b*n)//(q - 1))
+    exp(2π𝑖*(a*n)//(q - 1))
     0
 ```
 

--- a/docs/src/characters.md
+++ b/docs/src/characters.md
@@ -42,16 +42,16 @@ Generic character of GL2
     k ∈ {1,…, q - 1}, l ∈ {1,…, q - 1} except -l + k ∈ (q - 1)ℤ
   of degree q + 1
   with values
-    (q + 1)*exp(2π𝑖((i*l + i*k)//(q - 1)))
-    exp(2π𝑖((i*l + i*k)//(q - 1)))
-    exp(2π𝑖((i*l + j*k)//(q - 1))) + exp(2π𝑖((i*k + j*l)//(q - 1)))
+    (q + 1)*exp(2π𝑖*(i*l + i*k)//(q - 1))
+    exp(2π𝑖*(i*l + i*k)//(q - 1))
+    exp(2π𝑖*(i*l + j*k)//(q - 1)) + exp(2π𝑖*(i*k + j*l)//(q - 1))
     0
 
 julia> collect(ct)
 4-element Vector{GenericCharacterTables.GenericCyclo}:
- (q + 1)*exp(2π𝑖((i*l + i*k)//(q - 1)))
- exp(2π𝑖((i*l + i*k)//(q - 1)))
- exp(2π𝑖((i*l + j*k)//(q - 1))) + exp(2π𝑖((i*k + j*l)//(q - 1)))
+ (q + 1)*exp(2π𝑖*(i*l + i*k)//(q - 1))
+ exp(2π𝑖*(i*l + i*k)//(q - 1))
+ exp(2π𝑖*(i*l + j*k)//(q - 1)) + exp(2π𝑖*(i*k + j*l)//(q - 1)))
  0
 ```
 

--- a/docs/src/characters.md
+++ b/docs/src/characters.md
@@ -51,7 +51,7 @@ julia> collect(ct)
 4-element Vector{GenericCharacterTables.GenericCyclo}:
  (q + 1)*exp(2π𝑖*(i*l + i*k)//(q - 1))
  exp(2π𝑖*(i*l + i*k)//(q - 1))
- exp(2π𝑖*(i*l + j*k)//(q - 1)) + exp(2π𝑖*(i*k + j*l)//(q - 1)))
+ exp(2π𝑖*(i*l + j*k)//(q - 1)) + exp(2π𝑖*(i*k + j*l)//(q - 1))
  0
 ```
 

--- a/src/GenericCharacter.jl
+++ b/src/GenericCharacter.jl
@@ -16,10 +16,10 @@ Generic character of GL2
     kt1 ∈ {1,…, q - 1}, kt2 ∈ {1,…, q - 1}
   of degree q
   with values
-    q*exp(2π𝑖((2*i*kt1 + 2*i*kt2)//(q - 1)))
+    q*exp(2π𝑖*(2*i*kt1 + 2*i*kt2)//(q - 1))
     0
-    exp(2π𝑖((i*kt1 + i*kt2 + j*kt1 + j*kt2)//(q - 1)))
-    (-1)*exp(2π𝑖((i*kt1 + i*kt2)//(q - 1)))
+    exp(2π𝑖*(i*kt1 + i*kt2 + j*kt1 + j*kt2)//(q - 1))
+    -exp(2π𝑖*(i*kt1 + i*kt2)//(q - 1))
 ```
 """
 function tensor_product(char1::GenericCharacter, char2::GenericCharacter)
@@ -111,10 +111,10 @@ Generic character of GL2
     k ∈ {1,…, q - 1}
   of degree 1
   with values
-    exp(2π𝑖((2*i*k)//(q - 1)))
-    (q^2 - 1)*exp(2π𝑖((2*i*k)//(q - 1)))
-    (q^2 + q)*exp(2π𝑖((i*k + j*k)//(q - 1)))
-    (q^2 - q)*exp(2π𝑖((i*k)//(q - 1)))
+    exp(2π𝑖*(2*i*k)//(q - 1))
+    (q^2 - 1)*exp(2π𝑖*(2*i*k)//(q - 1))
+    (q^2 + q)*exp(2π𝑖*(i*k + j*k)//(q - 1))
+    (q^2 - q)*exp(2π𝑖*(i*k)//(q - 1))
 
 ```
 """
@@ -183,10 +183,10 @@ Generic character of GL2
     kl1 ∈ {1,…, q - 1}, kl2 ∈ {1,…, q - 1}
   of degree q + 5
   with values
-    (5)*exp(2π𝑖((2*i*kl1)//(q - 1))) + q*exp(2π𝑖((2*i*kl2)//(q - 1)))
-    (5)*exp(2π𝑖((2*i*kl1)//(q - 1)))
-    exp(2π𝑖((i*kl2 + j*kl2)//(q - 1))) + (5)*exp(2π𝑖((i*kl1 + j*kl1)//(q - 1)))
-    (-1)*exp(2π𝑖((i*kl2)//(q - 1))) + (5)*exp(2π𝑖((i*kl1)//(q - 1)))
+    5*exp(2π𝑖*(2*i*kl1)//(q - 1)) + q*exp(2π𝑖*(2*i*kl2)//(q - 1))
+    5*exp(2π𝑖*(2*i*kl1)//(q - 1))
+    exp(2π𝑖*(i*kl2 + j*kl2)//(q - 1)) + 5*exp(2π𝑖*(i*kl1 + j*kl1)//(q - 1))
+    -exp(2π𝑖*(i*kl2)//(q - 1)) + 5*exp(2π𝑖*(i*kl1)//(q - 1))
 ```
 """
 function linear_combination(coeffs::Vector{<:RingElement}, chars::Vector{<:GenericCharacter})
@@ -405,10 +405,10 @@ Generic character of GL2
     k ∈ {1,…, q - 1}
   of degree 1
   with values
-    exp(2π𝑖((2*i*k)//(q - 1)))
-    exp(2π𝑖((2*i*k)//(q - 1)))
-    exp(2π𝑖((i*k + j*k)//(q - 1)))
-    exp(2π𝑖((i*k)//(q - 1)))
+    exp(2π𝑖*(2*i*k)//(q - 1))
+    exp(2π𝑖*(2*i*k)//(q - 1))
+    exp(2π𝑖*(i*k + j*k)//(q - 1))
+    exp(2π𝑖*(i*k)//(q - 1))
 
 julia> q,(i,j,l,k) = parameters(g);
 
@@ -418,10 +418,10 @@ Generic character of GL2
     k ∈ {1,…, q - 1}, substitutions: i = q
   of degree 1
   with values
-    exp(2π𝑖((2*k)//(q - 1)))
-    exp(2π𝑖((2*k)//(q - 1)))
-    exp(2π𝑖((j*k + k)//(q - 1)))
-    exp(2π𝑖(k//(q - 1)))
+    exp(2π𝑖*(2*k)//(q - 1))
+    exp(2π𝑖*(2*k)//(q - 1))
+    exp(2π𝑖*(j*k + k)//(q - 1))
+    exp(2π𝑖*k//(q - 1))
 
 ```
 """
@@ -556,9 +556,9 @@ Generic character of GL2
     k ∈ {1,…, q - 1}, l ∈ {1,…, q - 1} except -l + k ∈ (q - 1)ℤ
   of degree q + 1
   with values
-    (q + 1)*exp(2π𝑖((i*l + i*k)//(q - 1)))
-    exp(2π𝑖((i*l + i*k)//(q - 1)))
-    exp(2π𝑖((i*l + j*k)//(q - 1))) + exp(2π𝑖((i*k + j*l)//(q - 1)))
+    (q + 1)*exp(2π𝑖*(i*l + i*k)//(q - 1))
+    exp(2π𝑖*(i*l + i*k)//(q - 1))
+    exp(2π𝑖*(i*l + j*k)//(q - 1)) + exp(2π𝑖*(i*k + j*l)//(q - 1))
     0
 
 julia> [g[3]]

--- a/src/GenericConjugacyClasses.jl
+++ b/src/GenericConjugacyClasses.jl
@@ -360,10 +360,10 @@ Generic conjugacy class of GL2
     i ∈ {1,…, q - 1}
   of order 1
   with values
-    exp(2π𝑖((2*i*k)//(q - 1)))
-    q*exp(2π𝑖((2*i*k)//(q - 1)))
-    (q + 1)*exp(2π𝑖((i*l + i*k)//(q - 1)))
-    (q - 1)*exp(2π𝑖((i*k)//(q - 1)))
+    exp(2π𝑖*(2*i*k)//(q - 1))
+    q*exp(2π𝑖*(2*i*k)//(q - 1))
+    (q + 1)*exp(2π𝑖*(i*l + i*k)//(q - 1))
+    (q - 1)*exp(2π𝑖*(i*k)//(q - 1))
 
 julia> q,(i,j,l,k) = parameters(g);
 
@@ -373,10 +373,10 @@ Generic conjugacy class of GL2
     i ∈ {1,…, q - 1}, substitutions: i = q
   of order 1
   with values
-    exp(2π𝑖((2*k)//(q - 1)))
-    q*exp(2π𝑖((2*k)//(q - 1)))
-    (q + 1)*exp(2π𝑖((l + k)//(q - 1)))
-    (q - 1)*exp(2π𝑖(k//(q - 1)))
+    exp(2π𝑖*(2*k)//(q - 1))
+    q*exp(2π𝑖*(2*k)//(q - 1))
+    (q + 1)*exp(2π𝑖*(l + k)//(q - 1))
+    (q - 1)*exp(2π𝑖*k//(q - 1))
 ```
 """
 function specialize(class::GenericConjugacyClass, var::UPoly, expr::RingElement)
@@ -512,9 +512,9 @@ Generic conjugacy class of GL2
     i ∈ {1,…, q - 1}, j ∈ {1,…, q - 1} except i - j ∈ (q - 1)ℤ
   of order q^2 + q
   with values
-    exp(2π𝑖((i*k + j*k)//(q - 1)))
-    exp(2π𝑖((i*k + j*k)//(q - 1)))
-    exp(2π𝑖((i*l + j*k)//(q - 1))) + exp(2π𝑖((i*k + j*l)//(q - 1)))
+    exp(2π𝑖*(i*k + j*k)//(q - 1))
+    exp(2π𝑖*(i*k + j*k)//(q - 1))
+    exp(2π𝑖*(i*l + j*k)//(q - 1)) + exp(2π𝑖*(i*k + j*l)//(q - 1))
     0
 
 julia> [conjugacy_class_type(g, 3)]

--- a/src/GenericCyclotomicFractions.jl
+++ b/src/GenericCyclotomicFractions.jl
@@ -24,7 +24,10 @@ function shrink(a::GenericCycloFrac)  # TODO Move this to the constructor of Gen
 end
 
 function expressify(x::GenericCycloFrac; context = nothing)
-  return Expr(:call, ://, expressify(x.numerator, context = context), expressify(x.denominator, context = context))
+  n = expressify(x.numerator; context)
+  isone(x.denominator) && return n
+  d = expressify(x.denominator; context)
+  return Expr(:call, ://, n, d)
 end
 
 @enable_all_show_via_expressify GenericCycloFrac

--- a/src/GenericCyclotomicFractions.jl
+++ b/src/GenericCyclotomicFractions.jl
@@ -23,14 +23,33 @@ function shrink(a::GenericCycloFrac)  # TODO Move this to the constructor of Gen
   return GenericCycloFrac(new_numerator, new_denominator, a.exceptions; simplify=false)
 end
 
-function expressify(x::GenericCycloFrac; context = nothing)
-  n = expressify(x.numerator; context)
-  isone(x.denominator) && return n
-  d = expressify(x.denominator; context)
-  return Expr(:call, ://, n, d)
+function show(io::IO, x::GenericCycloFrac)
+  io = pretty(io)
+  if isone(x.denominator)
+    print(io, "$(x.numerator)")
+  else
+    if isone(length(x.numerator.f))
+      print(io, "$(x.numerator)//")
+    else
+      print(io, "($(x.numerator))//")
+    end
+    if isone(length(x.denominator.f))
+      argument, modulus = collect(x.denominator.f)[1]
+      if iszero(argument) && (is_monomial(modulus) || is_constant(modulus))
+        print(io, "$(x.denominator)")
+      else
+        print(io, "($(x.denominator))")
+      end
+    else
+      print(io, "($(x.denominator))")
+    end
+  end
+  if is_restriction(x.exceptions)
+    print(io, "\nWith exceptions:\n", Indent())
+    print(io, x.exceptions)
+    print(io, Dedent())
+  end
 end
-
-@enable_all_show_via_expressify GenericCycloFrac
 
 isone(x::GenericCycloFrac) = isone(x.numerator) && isone(x.denominator)
 

--- a/src/GenericCyclotomicFractions.jl
+++ b/src/GenericCyclotomicFractions.jl
@@ -23,33 +23,11 @@ function shrink(a::GenericCycloFrac)  # TODO Move this to the constructor of Gen
   return GenericCycloFrac(new_numerator, new_denominator, a.exceptions; simplify=false)
 end
 
-function show(io::IO, x::GenericCycloFrac)
-  io = pretty(io)
-  if isone(x.denominator)
-    print(io, "$(x.numerator)")
-  else
-    if isone(length(x.numerator.f))
-      print(io, "$(x.numerator)//")
-    else
-      print(io, "($(x.numerator))//")
-    end
-    if isone(length(x.denominator.f))
-      argument, modulus = collect(x.denominator.f)[1]
-      if iszero(argument) && (is_monomial(modulus) || is_constant(modulus))
-        print(io, "$(x.denominator)")
-      else
-        print(io, "($(x.denominator))")
-      end
-    else
-      print(io, "($(x.denominator))")
-    end
-  end
-  if is_restriction(x.exceptions)
-    print(io, "\nWith exceptions:\n", Indent())
-    print(io, x.exceptions)
-    print(io, Dedent())
-  end
+function expressify(x::GenericCycloFrac; context = nothing)
+  return Expr(:call, ://, expressify(x.numerator, context = context), expressify(x.denominator, context = context))
 end
+
+@enable_all_show_via_expressify GenericCycloFrac
 
 isone(x::GenericCycloFrac) = isone(x.numerator) && isone(x.denominator)
 

--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -212,9 +212,8 @@ function show(io::IO, R::GenericCycloRing)
 end
 
 function expressify(x::GenericCyclo; context = nothing)
-  if iszero(x)
-    return 0
-  end
+  iszero(x) && return 0
+  isone(x) && return 1
   return reduce((a, b) -> Expr(:call, :+, a, b), map(p -> Expr(:call, :*, expressify(p[2], context = context), Expr(:call, Symbol("exp"), Expr(:call, :*, Symbol("2π𝑖"), expressify(p[1], context = context)))), collect(x.f)))
 end
 

--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -212,9 +212,19 @@ function show(io::IO, R::GenericCycloRing)
 end
 
 function expressify(x::GenericCyclo; context = nothing)
-  iszero(x) && return 0
-  isone(x) && return 1
-  return reduce((a, b) -> Expr(:call, :+, a, b), map(p -> Expr(:call, :*, expressify(p[2], context = context), Expr(:call, Symbol("exp"), Expr(:call, :*, Symbol("2π𝑖"), expressify(p[1], context = context)))), collect(x.f)))
+  sum = Expr(:call, :+)
+  for (argument, modulus) in x.f
+    modulus_expr = expressify(modulus; context)
+    if iszero(argument)
+      tmp = modulus_expr
+    else
+      argument_expr = expressify(argument; context)
+      exp_expr = Expr(:call, Symbol("exp"), Expr(:call, :*, Symbol("2π𝑖"), argument_expr))
+      tmp = Expr(:call, :*, modulus_expr, exp_expr)
+    end
+    push!(sum.args, tmp)
+  end
+  return sum
 end
 
 @enable_all_show_via_expressify GenericCyclo

--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -211,26 +211,14 @@ function show(io::IO, R::GenericCycloRing)
   end
 end
 
-function show(io::IO, x::GenericCyclo)  # TODO Use OSCAR's expressify system here.
+function expressify(x::GenericCyclo; context = nothing)
   if iszero(x)
-    print(io, "0")
-    return nothing
+    return 0
   end
-  for (i, (argument, modulus)) in enumerate(x.f)
-    if iszero(argument)
-      print(io, modulus)
-    elseif isone(modulus)
-      print(io, "exp(2π𝑖($(argument)))")
-    elseif is_monomial(modulus)
-      print(io, "$(modulus)*exp(2π𝑖($(argument)))")
-    else
-      print(io, "($(modulus))*exp(2π𝑖($(argument)))")
-    end
-    if i < length(x.f)
-      print(io, " + ")
-    end
-  end
+  return reduce((a, b) -> Expr(:call, :+, a, b), map(p -> Expr(:call, :*, expressify(p[2], context = context), Expr(:call, Symbol("exp"), Expr(:call, :*, Symbol("2π𝑖"), expressify(p[1], context = context)))), collect(x.f)))
 end
+
+@enable_all_show_via_expressify GenericCyclo
 
 # Unary operations
 

--- a/src/SumProc.jl
+++ b/src/SumProc.jl
@@ -16,10 +16,10 @@ julia> S = generic_cyclotomic_ring(R);
 julia> i, j, k, l = gens(R, ["i", "j", "k", "l"]);
 
 julia> a = S(Dict(2//(q-1)*i*j+1//q*k^2+1//2*i*l => R(1)))
-exp(2π𝑖((1//2*q^2*i*l + 2*q*i*j - 1//2*q*i*l + q*k^2 - k^2)//(q^2 - q)))
+exp(2π𝑖*(1//2*q^2*i*l + 2*q*i*j - 1//2*q*i*l + q*k^2 - k^2)//(q^2 - q))
 
 julia> evaluate(a,[i,k],[j,3*i])
-exp(2π𝑖((1//2*q^2*j*l + 9*q*i^2 + 2*q*j^2 - 1//2*q*j*l - 9*i^2)//(q^2 - q)))
+exp(2π𝑖*(1//2*q^2*j*l + 9*q*i^2 + 2*q*j^2 - 1//2*q*j*l - 9*i^2)//(q^2 - q))
 
 ```
 """
@@ -44,7 +44,7 @@ julia> S = generic_cyclotomic_ring(R);
 julia> i, = gens(R, ["i"]);
 
 julia> a = S(Dict(1//(q-1)*i => R(1)))
-exp(2π𝑖(i//(q - 1)))
+exp(2π𝑖*i//(q - 1))
 
 julia> GenericCharacterTables.nesum(a, i, 1, q-1)
 0

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -54,7 +54,7 @@ julia> q = gen(R, "q");
 julia> S = generic_cyclotomic_ring(R);
 
 julia> S(q; exponent=1//(q-1))
-q*exp(2π𝑖(1//(q - 1)))
+q*exp(2π𝑖*1//(q - 1))
 ```
 """
 mutable struct GenericCyclo <: RingElem
@@ -94,13 +94,13 @@ julia> q = gen(R, "q");
 julia> S = generic_cyclotomic_ring(R);
 
 julia> a = S(q; exponent=1//(q-1))
-q*exp(2π𝑖(1//(q - 1)))
+q*exp(2π𝑖*1//(q - 1))
 
 julia> b = S(q^2; exponent=1//(q^2-1))
-q^2*exp(2π𝑖(1//(q^2 - 1)))
+q^2*exp(2π𝑖*1//(q^2 - 1))
 
 julia> a//b
-q*exp(2π𝑖(1//(q - 1)))//(q^2*exp(2π𝑖(1//(q^2 - 1))))
+q*exp(2π𝑖*1//(q - 1))//(q^2*exp(2π𝑖*1//(q^2 - 1)))
 ```
 """
 struct GenericCycloFrac
@@ -234,10 +234,10 @@ Generic character of GL2
     k ∈ {1,…, q - 1}
   of degree 1
   with values
-    exp(2π𝑖((2*i*k)//(q - 1)))
-    exp(2π𝑖((2*i*k)//(q - 1)))
-    exp(2π𝑖((i*k + j*k)//(q - 1)))
-    exp(2π𝑖((i*k)//(q - 1)))
+    exp(2π𝑖*(2*i*k)//(q - 1))
+    exp(2π𝑖*(2*i*k)//(q - 1))
+    exp(2π𝑖*(i*k + j*k)//(q - 1))
+    exp(2π𝑖*(i*k)//(q - 1))
 ```
 """
 struct GenericCharacter <: AbstractGenericCharacter


### PR DESCRIPTION
I took a little closer look at the expressify system. Apart from the obvious fact that the doctests will still fail I see two other problems. The result of an ordinary scalar product is a `GenericCycloFrac` for technical reasons. This leads to scalar product results like `1//1` instead of simply `1` . Another problem is that obviously expressions like `exp(0)` are not automatically simplified to `1`. So without any manual intervention things like `0//exp(0)` will be printed.