### PR TITLE
Fix table loading in latest julia

### DIFF
--- a/src/CharTable.jl
+++ b/src/CharTable.jl
@@ -48,9 +48,9 @@ iterate(c::AbstractGenericCharacter, state::Integer=1) =
   state > length(c) ? nothing : (c[state], state + 1)
 
 function loadtab(path::String)
-  return (@eval module $(gensym("CHAR_TABLE"))
-  include($(path))
-  end).TABLE
+  return Base.invokelatest(getproperty, (@eval module $(gensym("CHAR_TABLE"))
+    include($(path))
+    end), :TABLE)
 end
 
 function gentab(table::String, tabletype::String)


### PR DESCRIPTION
cc @SoongNoonien @fingolfin 

This should fix the CI jobs `(nightly, devel)` and (once https://github.com/oscar-system/GenericCharacterTables.jl/pull/253 is merged) `(1.12-nightly, devel)` and `(1.12-nightly, stable)`.

Failure of `(nightly, stable)` is expected until there is a new Oscar release that includes binaries for GAP and singular that were compiled against julia 1.13.