### PR TITLE
Compute `normal_form` with mpolys

### DIFF
--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -64,7 +64,7 @@ julia> kempner(12)
 kempner(m::Int64) = kempner_with_data(m)[1]
 
 @doc raw"""
-    normal_form(f::ZZUPoly, m::Int64)
+    normal_form(f::MPolyRingElem{ZZRingElem}, m::Int64)
 
 Return a normal form of `f` modulo `m`, such that `normal_form(f,m)` is equal
 to `normal_form(g,m)` if and only if `f` and `g` are congruent modulo `m`.
@@ -89,7 +89,7 @@ julia> normal_form(4*x^9+x^7-(x^3+4*x),12)
 
 ```
 """
-function normal_form(f::ZZUPoly, m::Int64)
+function normal_form(f::MPolyRingElem{ZZRingElem}, m::Int64)
   if m < 1
     throw(DomainError(m, "A normal form for non-positive moduli is not defined!"))
   end
@@ -131,6 +131,8 @@ function normal_form(f::ZZUPoly, m::Int64)
   end
   return f
 end
+
+normal_form(f::ZZUPoly, m::Int64) = Generic.UnivPoly(normal_form(data(f), m), parent(f))
 
 strip_zeros!(f::Dict{UPolyFrac,UPoly}) = filter!(p -> !iszero(p.second), f)
 


### PR DESCRIPTION
As proposed in #250 I tried to perform some computations with mpolys. This is the result when the `normal_form` computation is done with mpolys instead of upolys.

With current master:
```
julia> @time scalar_test(g)
 76.226584 seconds (236.21 M allocations: 24.637 GiB, 12.26% gc time, 6.17% compilation time)

julia> @time scalar_test(g)
 70.591532 seconds (233.28 M allocations: 24.491 GiB, 12.26% gc time)

```

With this PR:
```
julia> @time scalar_test(g)
 74.355277 seconds (235.96 M allocations: 24.629 GiB, 12.84% gc time, 6.04% compilation time)

julia> @time scalar_test(g)
 69.110084 seconds (233.02 M allocations: 24.484 GiB, 11.68% gc time)

```
