### PR TITLE
Allow raising cyclotomics to a `UPoly`

### DIFF
--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -284,6 +284,14 @@ end
 
 *(x::GenericCyclo, y::UPoly) = y * x
 
+function ^(x::GenericCyclo, y::UPoly)
+  if isone(length(x.f))
+    expo, c = collect(x.f)[1]
+    return parent(x)(Dict(y*expo => c))
+  end
+  throw(ArgumentError("cyclotomic has to many summands"))
+end
+
 # Comparison
 
 function ==(x::GenericCyclo, y::GenericCyclo)  # TODO Make compatible with hashes. There might be some missing theory...

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,6 +86,10 @@ test_Ring_interface(S)
   @test a == cb
   @test b == y
   @test c == z
+
+  a = S(1; exponent=(2 * i * j) * 1//R((q - 1)))
+  @test isone(a^(q-1))
+  @test a == a^q
 end
 
 @testset "Shifts" begin


### PR DESCRIPTION
In preparation to #261 we should allow raising generic cyclotomics to more general powers.