### PR TITLE
Adapt to better conformance test interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,5 +11,5 @@ Oscar = "f1435218-dba5-11e9-1e4d-f1a5fab5fc13"
 [compat]
 Compat = "4.11"
 JSON = "^0.20, ^0.21"
-Oscar = "1.1"
+Oscar = "1.3"
 julia = "1.6"

--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -346,6 +346,10 @@ rand(rng::AbstractRNG, R::GenericCycloRing, n::AbstractUnitRange{Int}) = R(rand(
 
 rand(R::GenericCycloRing, n::AbstractUnitRange{Int}) = rand(Random.GLOBAL_RNG, R, n)
 
+function ConformanceTests.generate_element(R::GenericCycloRing)
+  return rand(R, -999:999)
+end
+
 # Promotion rules
 
 promote_rule(::Type{GenericCyclo}, ::Type{GenericCyclo}) = GenericCyclo

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,27 +1,15 @@
 using GenericCharacterTables
 using GenericCharacterTables.Oscar
 using Test
-include(
-  joinpath(
-    pathof(GenericCharacterTables.Oscar.AbstractAlgebra),
-    "..",
-    "..",
-    "test",
-    "Rings-conformance-tests.jl",
-  ),
-)
 
 include("Aqua.jl")
 
-R = universal_polynomial_ring(QQ)
-q, i, j = gens(R, ["q", "i", "j"])
-S = generic_cyclotomic_ring(R)
-
-function test_elem(R::GenericCharacterTables.GenericCycloRing)
-  return rand(R, -999:999)
+@testset "Conformance tests" begin
+  R = universal_polynomial_ring(QQ)
+  q, i, j = gens(R, ["q", "i", "j"])
+  S = generic_cyclotomic_ring(R)
+  ConformanceTests.test_Ring_interface(S)
 end
-
-test_Ring_interface(S)
 
 @testset "GenericCyclo" begin
   R = universal_polynomial_ring(QQ)


### PR DESCRIPTION
This interface was introduced in AA v0.44.5 (https://github.com/Nemocas/AbstractAlgebra.jl/issues/1936), and the old one will be removed with the next breaking AA release.

This PR adapts the uses in GCT to the new interface. However, this requires a bump to the minimum required OSCAR version. I don't know what your convention is regarding that, but you could also just keep this PR around unmerged until the old interface is removed altogether and only merge it then.