### PR TITLE
Improve `^` for `GenericCyclo`

### DIFF
--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -286,12 +286,20 @@ end
 
 *(x::GenericCyclo, y::UPoly) = y * x
 
-function ^(x::GenericCyclo, y::UPoly)
-  if isone(length(x.f))
-    expo, c = collect(x.f)[1]
-    return parent(x)(Dict(y*expo => c))
+function ^(x::GenericCyclo, y::Union{UPoly, Rational})
+  isone(length(x.f)) || error("cyclotomic has to many summands")
+  expo, c = collect(x.f)[1]
+  if iszero(expo) && isone(-c)  # in this case x is the primitive second root of unity -1
+    c = -c
+    y = 1//2*y
   end
-  throw(ArgumentError("cyclotomic has to many summands"))
+  isone(c) || error("cyclotomic is not a root of unity")
+  S = parent(x)
+  R = base_ring(S)
+  if iszero(expo)
+    return S(Dict(R(y)//R(1) => R(1)))
+  end
+  return S(Dict(y*expo => R(1)))
 end
 
 # Comparison

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,6 +82,10 @@ end
   a = S(1; exponent=(2 * i * j) * 1//R((q - 1)))
   @test isone(a^(q-1))
   @test a == a^q
+
+  @test E(1)^(1//2) == E(2)
+  @test E(2)^(1//3) == E(6)
+  @test E(3)^(1//2) == E(6)
 end
 
 @testset "Shifts" begin


### PR DESCRIPTION
As discussed earlier I've adjusted `^` for `GenericCyclo` to allow rational exponents. While thinking about tests to implement I've noticed that the original implementation was flawed. Things like `(2*E(3))^(1//2)` would silently return `2*E(6)`. Also `E(2)^(1//3)` returned `-1` while `E(3)^(1//2)` returned `E(6)` as I would have expected. With the adjustments needed for these things to fix, some return values might now be a bit unexpected. For example `E(1)^(1//3)` now returns `E(3)`. At least to me that is not a problem, I think I even like it.