### PR TITLE
Add decomposition helper

### DIFF
--- a/src/GenericCharacter.jl
+++ b/src/GenericCharacter.jl
@@ -392,6 +392,20 @@ function scalar_product(
   return sum//order(t)
 end
 
+function character_decomposition_multiplicity(char1::GenericCharacter, char2::GenericCharacter, char3::GenericCharacter)
+  check_parent(char1, char2)
+  check_parent(char1, char3)
+  t = parent(char1)
+  sum = 0
+  for class in 1:number_of_conjugacy_class_types(t)
+    val1 = shift_char_parameters(t, char1[class], 1)
+    val2 = shift_char_parameters(t, char2[class], 2)
+    val3 = shift_char_parameters(t, char3[class], 3)
+    sum += t.classlength[class] * classsum(t, class, val1 * val2 * conj(val3))
+  end
+  return shrink(sum//order(t))
+end
+
 @doc raw"""
     specialize(char::GenericCharacter, var::UPoly, expr::RingElement)
 


### PR DESCRIPTION
In the talk of Meinolf Geck at the SFB retreat he presented a decomposition helper function:
![Bildschirmfoto vom 2025-03-31 09-35-50](https://github.com/user-attachments/assets/44a6be25-45ca-41b4-ba03-140cdfd51e36)
This PR provides a first implementation. I think we should also check if all involved character types are irreducible. As far as I understand this `character_decomposition_multiplicity(a,b,c)` should be more or less equivalent to `scalar_product(a*b,c)`, maybe this can also be used for some tests. Perhaps we could even incorporate this into the book example. 