### PR TITLE
Some more tweaks for the table info

### DIFF
--- a/data/Greenfunctions/2A2/GU3.jl
+++ b/data/Greenfunctions/2A2/GU3.jl
@@ -21,7 +21,7 @@ classtypeorder = R.([1, 1, 1])
 charinfo = Vector{Any}[[[1, 1, 1]], [[2, 1]], [[3]]]
 chardegree = R.([-(q - 1) * (q^2 - q + 1), (q + 1) * (q^2 - q + 1), -(q + 1)^2 * (q - 1)])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GU}_3(q)$.
+information = raw"""The Green functions of $\mathrm{GU}_3(q)$.
 
 - CHEVIE-name of the table: `GU3green`
 

--- a/data/Greenfunctions/2A2/GU3.jl
+++ b/data/Greenfunctions/2A2/GU3.jl
@@ -23,8 +23,6 @@ chardegree = R.([-(q - 1) * (q^2 - q + 1), (q + 1) * (q^2 - q + 1), -(q + 1)^2 *
 
 information = raw"""The Green functions of $\mathrm{GU}_3(q)$.
 
-
-
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_3(q^2)$ from those of $\mathrm{GL}_3(q)$
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).

--- a/data/Greenfunctions/2A2/GU3.jl
+++ b/data/Greenfunctions/2A2/GU3.jl
@@ -23,7 +23,7 @@ chardegree = R.([-(q - 1) * (q^2 - q + 1), (q + 1) * (q^2 - q + 1), -(q + 1)^2 *
 
 information = raw"""The Green functions of $\mathrm{GU}_3(q)$.
 
-- CHEVIE-name of the table: `GU3green`
+
 
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_3(q^2)$ from those of $\mathrm{GL}_3(q)$

--- a/data/Greenfunctions/2A3/GU4.jl
+++ b/data/Greenfunctions/2A3/GU4.jl
@@ -50,7 +50,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_4(q)$.
 
-- CHEVIE-name of the table: `GU4green`
+
 
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_4(q^2)$ from those of $\mathrm{GL}_4(q)$

--- a/data/Greenfunctions/2A3/GU4.jl
+++ b/data/Greenfunctions/2A3/GU4.jl
@@ -50,8 +50,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_4(q)$.
 
-
-
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_4(q^2)$ from those of $\mathrm{GL}_4(q)$
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).

--- a/data/Greenfunctions/2A3/GU4.jl
+++ b/data/Greenfunctions/2A3/GU4.jl
@@ -48,7 +48,7 @@ chardegree =
     (q^2 + 1) * (q - 1)^2 * (q + 1)^2,
     -(q - 1) * (q^2 - q + 1) * (q + 1)^3])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GU}_4(q)$.
+information = raw"""The Green functions of $\mathrm{GU}_4(q)$.
 
 - CHEVIE-name of the table: `GU4green`
 

--- a/data/Greenfunctions/2A4/GU5.jl
+++ b/data/Greenfunctions/2A4/GU5.jl
@@ -88,8 +88,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_5(q)$.
 
-
-
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_5(q^2)$ from those of $\mathrm{GL}_5(q)$
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).

--- a/data/Greenfunctions/2A4/GU5.jl
+++ b/data/Greenfunctions/2A4/GU5.jl
@@ -88,7 +88,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_5(q)$.
 
-- CHEVIE-name of the table: `GU5green`
+
 
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_5(q^2)$ from those of $\mathrm{GL}_5(q)$

--- a/data/Greenfunctions/2A4/GU5.jl
+++ b/data/Greenfunctions/2A4/GU5.jl
@@ -86,7 +86,7 @@ chardegree =
     -(q - 1) * (q^2 - q + 1) * (q^4 - q^3 + q^2 - q + 1) * (q + 1)^3,
     (q^2 - q + 1) * (q^2 + 1) * (q - 1)^2 * (q + 1)^4])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GU}_5(q)$.
+information = raw"""The Green functions of $\mathrm{GU}_5(q)$.
 
 - CHEVIE-name of the table: `GU5green`
 

--- a/data/Greenfunctions/2A5/GU6.jl
+++ b/data/Greenfunctions/2A5/GU6.jl
@@ -199,7 +199,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_6(q)$.
 
-- CHEVIE-name of the table: `GU6green`
+
 
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_6(q^2)$ from those of $\mathrm{GL}_6(q)$

--- a/data/Greenfunctions/2A5/GU6.jl
+++ b/data/Greenfunctions/2A5/GU6.jl
@@ -199,8 +199,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_6(q)$.
 
-
-
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_6(q^2)$ from those of $\mathrm{GL}_6(q)$
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).

--- a/data/Greenfunctions/2A5/GU6.jl
+++ b/data/Greenfunctions/2A5/GU6.jl
@@ -197,7 +197,7 @@ chardegree =
     -(q^2 + 1) * (q^2 + q + 1) * (q^2 - q + 1)^2 * (q - 1)^3 * (q + 1)^4,
     (q^2 - q + 1) * (q^4 - q^3 + q^2 - q + 1) * (q^2 + 1) * (q - 1)^2 * (q + 1)^5])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GU}_6(q)$.
+information = raw"""The Green functions of $\mathrm{GU}_6(q)$.
 
 - CHEVIE-name of the table: `GU6green`
 

--- a/data/Greenfunctions/2A6/GU7.jl
+++ b/data/Greenfunctions/2A6/GU7.jl
@@ -359,8 +359,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_7(q)$.
 
-
-
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_7(q^2)$ from those of $\mathrm{GL}_7(q)$
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).

--- a/data/Greenfunctions/2A6/GU7.jl
+++ b/data/Greenfunctions/2A6/GU7.jl
@@ -359,7 +359,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_7(q)$.
 
-- CHEVIE-name of the table: `GU7green`
+
 
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_7(q^2)$ from those of $\mathrm{GL}_7(q)$

--- a/data/Greenfunctions/2A6/GU7.jl
+++ b/data/Greenfunctions/2A6/GU7.jl
@@ -357,7 +357,7 @@ chardegree =
     -(q^2 + q + 1) * (q^4 - q^3 + q^2 - q + 1) * (q^2 + 1) * (q^2 - q + 1)^2 * (q - 1)^3 *
     (q + 1)^6])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GU}_7(q)$.
+information = raw"""The Green functions of $\mathrm{GU}_7(q)$.
 
 - CHEVIE-name of the table: `GU7green`
 

--- a/data/Greenfunctions/2A7/GU8.jl
+++ b/data/Greenfunctions/2A7/GU8.jl
@@ -777,7 +777,7 @@ chardegree =
     -(q^2 + q + 1) * (q^4 - q^3 + q^2 - q + 1) * (q^6 - q^5 + q^4 - q^3 + q^2 - q + 1) *
     (q^2 + 1) * (q^2 - q + 1)^2 * (q - 1)^3 * (q + 1)^7])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GU}_8(q^2)$.
+information = raw"""The Green functions of $\mathrm{GU}_8(q^2)$.
 
 - CHEVIE-name of the table: `GU8green`
 

--- a/data/Greenfunctions/2A7/GU8.jl
+++ b/data/Greenfunctions/2A7/GU8.jl
@@ -779,8 +779,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_8(q^2)$.
 
-
-
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_8(q^2)$ from those of $\mathrm{GL}_8(q)$
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).

--- a/data/Greenfunctions/2A7/GU8.jl
+++ b/data/Greenfunctions/2A7/GU8.jl
@@ -779,7 +779,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_8(q^2)$.
 
-- CHEVIE-name of the table: `GU8green`
+
 
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_8(q^2)$ from those of $\mathrm{GL}_8(q)$

--- a/data/Greenfunctions/2A8/GU9.jl
+++ b/data/Greenfunctions/2A8/GU9.jl
@@ -1605,7 +1605,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_9(q)$.
 
-- CHEVIE-name of the table: `GU9green`
+
 
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_9(q^2)$ from those of $\mathrm{GL}_9(q)$

--- a/data/Greenfunctions/2A8/GU9.jl
+++ b/data/Greenfunctions/2A8/GU9.jl
@@ -1605,8 +1605,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GU}_9(q)$.
 
-
-
 - By a theorem of Hotta, Springer and Kawanaka we can get the Green
   functions of the unitary group $\mathrm{GU}_9(q^2)$ from those of $\mathrm{GL}_9(q)$
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).

--- a/data/Greenfunctions/2A8/GU9.jl
+++ b/data/Greenfunctions/2A8/GU9.jl
@@ -1603,7 +1603,7 @@ chardegree =
     (q^6 - q^5 + q^4 - q^3 + q^2 - q + 1) * (q^2 - q + 1)^2 * (q^2 + 1)^2 * (q - 1)^4 *
     (q + 1)^8])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GU}_9(q)$.
+information = raw"""The Green functions of $\mathrm{GU}_9(q)$.
 
 - CHEVIE-name of the table: `GU9green`
 

--- a/data/Greenfunctions/2B2/2B2.jl
+++ b/data/Greenfunctions/2B2/2B2.jl
@@ -33,7 +33,7 @@ chardegree =
 
 information = raw"""The Green functions of $^2\mathrm{B}_2(q^2)$.
 
-- CHEVIE-name of the table: `2B2green`
+
 
 - The table was first computed in [Suz62](@cite).
 """

--- a/data/Greenfunctions/2B2/2B2.jl
+++ b/data/Greenfunctions/2B2/2B2.jl
@@ -31,7 +31,7 @@ charinfo = Vector{Any}[["T_1"], ["T_2"], ["T_3"]]
 chardegree =
   R.([q^4 + 1, -(q^2 - 1) * (q^2 - sqrt2 * q + 1), -(q^2 - 1) * (q^2 + sqrt2 * q + 1)])
 
-information = raw"""- Information about the Green functions of $^2\mathrm{B}_2(q^2)$.
+information = raw"""The Green functions of $^2\mathrm{B}_2(q^2)$.
 
 - CHEVIE-name of the table: `2B2green`
 

--- a/data/Greenfunctions/2B2/2B2.jl
+++ b/data/Greenfunctions/2B2/2B2.jl
@@ -33,8 +33,6 @@ chardegree =
 
 information = raw"""The Green functions of $^2\mathrm{B}_2(q^2)$.
 
-
-
 - The table was first computed in [Suz62](@cite).
 """
 

--- a/data/Greenfunctions/2D4/2D4n2.jl
+++ b/data/Greenfunctions/2D4/2D4n2.jl
@@ -125,7 +125,7 @@ chardegree = R.([0, 0, 0, 0, 0, 0, 0, 0, 0])
 
 information = raw"""The Green functions of $\mathrm{O}_8^-(q)$ with odd $q$.
 
-- CHEVIE-name of the table: `2D4n2green`
+
 
 - This table of generalized Green functions is computed by F. Lübeck
   using Lusztig's algorithm.`,`

--- a/data/Greenfunctions/2D4/2D4n2.jl
+++ b/data/Greenfunctions/2D4/2D4n2.jl
@@ -125,8 +125,6 @@ chardegree = R.([0, 0, 0, 0, 0, 0, 0, 0, 0])
 
 information = raw"""The Green functions of $\mathrm{O}_8^-(q)$ with odd $q$.
 
-
-
 - This table of generalized Green functions is computed by F. Lübeck
   using Lusztig's algorithm.`,`
 - The occuring Levi subgroups have the following relative (twisted)

--- a/data/Greenfunctions/2D4/2D4n2.jl
+++ b/data/Greenfunctions/2D4/2D4n2.jl
@@ -123,7 +123,7 @@ charinfo = Vector{Any}[ # TODO
 
 chardegree = R.([0, 0, 0, 0, 0, 0, 0, 0, 0])
 
-information = raw"""- Information about the Green functions of $\mathrm{O}_8^-(q)$ with odd $q$.
+information = raw"""The Green functions of $\mathrm{O}_8^-(q)$ with odd $q$.
 
 - CHEVIE-name of the table: `2D4n2green`
 

--- a/data/Greenfunctions/2D4/2D4n2.jl
+++ b/data/Greenfunctions/2D4/2D4n2.jl
@@ -127,7 +127,7 @@ information = raw"""- Information about the Green functions of $\mathrm{O}_8^-(q
 
 - CHEVIE-name of the table: `2D4n2green`
 
-- This table of generalized Green functions is computed by F.Luebeck 
+- This table of generalized Green functions is computed by F. Lübeck
   using Lusztig's algorithm.`,`
 - The occuring Levi subgroups have the following relative (twisted)
   Weyl groups:

--- a/data/Greenfunctions/2D4/2D4p2.jl
+++ b/data/Greenfunctions/2D4/2D4p2.jl
@@ -140,8 +140,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{O}_8^-(2^n)$.
 
-
-
 - The table was published in [Mal93](@cite)
 
 - The notation for the unipotent classes is as in that paper.

--- a/data/Greenfunctions/2D4/2D4p2.jl
+++ b/data/Greenfunctions/2D4/2D4p2.jl
@@ -140,7 +140,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{O}_8^-(2^n)$.
 
-- CHEVIE-name of the table: `2D4p2green`
+
 
 - The table was published in [Mal93](@cite)
 

--- a/data/Greenfunctions/2D4/2D4p2.jl
+++ b/data/Greenfunctions/2D4/2D4p2.jl
@@ -138,7 +138,7 @@ chardegree =
     -(q - 1)^3 * (q + 1) * (q^2 + q + 1) * (q^2 - q + 1) * (q^4 + 1),
     -(q - 1)^3 * (q + 1)^3 * (q^2 + q + 1) * (q^2 + 1) * (q^2 - q + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{O}_8^-(2^n)$.
+information = raw"""The Green functions of $\mathrm{O}_8^-(2^n)$.
 
 - CHEVIE-name of the table: `2D4p2green`
 

--- a/data/Greenfunctions/2E6/2E6n23.jl
+++ b/data/Greenfunctions/2E6/2E6n23.jl
@@ -1023,7 +1023,7 @@ chardegree =
     -(q^2 + 1) * (q^4 - q^3 + q^2 - q + 1) * (q^2 + q + 1) * (q^4 - q^2 + 1) * (q^4 + 1) *
     (1 - q^3 + q^6) * (q - 1)^3 * (q^2 - q + 1)^3 * (q + 1)^5])
 
-information = raw"""- Information about the Green functions of $^2\mathrm{E}_6(q)$, $p>3$.
+information = raw"""The Green functions of $^2\mathrm{E}_6(q)$, $p>3$.
 
 - CHEVIE-name of the table: `2E6n23green`
 

--- a/data/Greenfunctions/2E6/2E6n23.jl
+++ b/data/Greenfunctions/2E6/2E6n23.jl
@@ -1025,7 +1025,7 @@ chardegree =
 
 information = raw"""The Green functions of $^2\mathrm{E}_6(q)$, $p>3$.
 
-- CHEVIE-name of the table: `2E6n23green`
+
 
 - The table was first computed in [BS84](@cite).
 """

--- a/data/Greenfunctions/2E6/2E6n23.jl
+++ b/data/Greenfunctions/2E6/2E6n23.jl
@@ -1025,8 +1025,6 @@ chardegree =
 
 information = raw"""The Green functions of $^2\mathrm{E}_6(q)$, $p>3$.
 
-
-
 - The table was first computed in [BS84](@cite).
 """
 

--- a/data/Greenfunctions/2E6/2E6p2.jl
+++ b/data/Greenfunctions/2E6/2E6p2.jl
@@ -1103,7 +1103,7 @@ chardegree =
     -(q - 1)^3 * (q + 1)^5 * (q^2 + 1) * (q^4 - q^3 + q^2 - q + 1) * (q^2 + q + 1) *
     (q^4 - q^2 + 1) * (q^4 + 1) * (q^6 - q^3 + 1) * (q^2 - q + 1)^3])
 
-information = raw"""- Information about the Green functions of $^2\mathrm{E}_6(2^n)$.
+information = raw"""The Green functions of $^2\mathrm{E}_6(2^n)$.
 
 - CHEVIE-name of the table: `2E6p2green`
 

--- a/data/Greenfunctions/2E6/2E6p2.jl
+++ b/data/Greenfunctions/2E6/2E6p2.jl
@@ -1105,8 +1105,6 @@ chardegree =
 
 information = raw"""The Green functions of $^2\mathrm{E}_6(2^n)$.
 
-
-
 - The table was first computed in [Mal93](@cite).
 
 - The notation for the unipotent classes is as in that paper.

--- a/data/Greenfunctions/2E6/2E6p2.jl
+++ b/data/Greenfunctions/2E6/2E6p2.jl
@@ -1105,7 +1105,7 @@ chardegree =
 
 information = raw"""The Green functions of $^2\mathrm{E}_6(2^n)$.
 
-- CHEVIE-name of the table: `2E6p2green`
+
 
 - The table was first computed in [Mal93](@cite).
 

--- a/data/Greenfunctions/2F4/2F4.jl
+++ b/data/Greenfunctions/2F4/2F4.jl
@@ -318,7 +318,7 @@ chardegree =
 
 information = raw"""The Green functions of $^2\mathrm{F}_4(q^2)$.
 
-- CHEVIE-name of the table: `2F4green`
+
 
 - The Green functions can easily be obtained from a knowledge of the unipotent
   characters; these were first computed in [Mal90](@cite).

--- a/data/Greenfunctions/2F4/2F4.jl
+++ b/data/Greenfunctions/2F4/2F4.jl
@@ -316,7 +316,7 @@ chardegree =
     (q^2 + 1)^2 * (q^2 - 1)^2 * (q^4 + 1)^2 * (q^4 - q^2 + 1) *
     (q^4 - sqrt2 * q^3 + q^2 - sqrt2 * q + 1)])
 
-information = raw"""- Information about the Green functions of $^2\mathrm{F}_4(q^2)$.
+information = raw"""The Green functions of $^2\mathrm{F}_4(q^2)$.
 
 - CHEVIE-name of the table: `2F4green`
 

--- a/data/Greenfunctions/2F4/2F4.jl
+++ b/data/Greenfunctions/2F4/2F4.jl
@@ -318,8 +318,6 @@ chardegree =
 
 information = raw"""The Green functions of $^2\mathrm{F}_4(q^2)$.
 
-
-
 - The Green functions can easily be obtained from a knowledge of the unipotent
   characters; these were first computed in [Mal90](@cite).
 

--- a/data/Greenfunctions/2G2/2G2.jl
+++ b/data/Greenfunctions/2G2/2G2.jl
@@ -56,7 +56,7 @@ chardegree =
 
 information = raw"""The Green functions of $^2\mathrm{G}_2(q^2)$.
 
-- CHEVIE-name of the table: `2G2green`
+
 
 - The table was first computed in [War66](@cite).
 """

--- a/data/Greenfunctions/2G2/2G2.jl
+++ b/data/Greenfunctions/2G2/2G2.jl
@@ -56,8 +56,6 @@ chardegree =
 
 information = raw"""The Green functions of $^2\mathrm{G}_2(q^2)$.
 
-
-
 - The table was first computed in [War66](@cite).
 """
 

--- a/data/Greenfunctions/2G2/2G2.jl
+++ b/data/Greenfunctions/2G2/2G2.jl
@@ -54,7 +54,7 @@ chardegree =
     -(q^4 - 1) * (q^2 + sqrt3 * q + 1),
   ])
 
-information = raw"""- Information about the Green functions of $^2\mathrm{G}_2(q^2)$.
+information = raw"""The Green functions of $^2\mathrm{G}_2(q^2)$.
 
 - CHEVIE-name of the table: `2G2green`
 

--- a/data/Greenfunctions/3D4/3D4n2.jl
+++ b/data/Greenfunctions/3D4/3D4n2.jl
@@ -82,7 +82,7 @@ chardegree =
 
 information = raw"""The Green functions of $^3\mathrm{D}_4(q)$, $p>2$.
 
-- CHEVIE-name of the table: `3D4n2green`
+
 
 - The table was first computed in [Spa82*1](@cite).
 """

--- a/data/Greenfunctions/3D4/3D4n2.jl
+++ b/data/Greenfunctions/3D4/3D4n2.jl
@@ -82,8 +82,6 @@ chardegree =
 
 information = raw"""The Green functions of $^3\mathrm{D}_4(q)$, $p>2$.
 
-
-
 - The table was first computed in [Spa82*1](@cite).
 """
 

--- a/data/Greenfunctions/3D4/3D4n2.jl
+++ b/data/Greenfunctions/3D4/3D4n2.jl
@@ -80,7 +80,7 @@ chardegree =
     (q + 1)^2 * (q - 1)^2 * (q^2 - q + 1)^2 * (q^2 + q + 1)^2,
     (q^2 - q + 1) * (q^4 - q^2 + 1) * (q - 1)^2 * (q^2 + q + 1)^2])
 
-information = raw"""- Information about the Green functions of $^3\mathrm{D}_4(q)$, $p>2$.
+information = raw"""The Green functions of $^3\mathrm{D}_4(q)$, $p>2$.
 
 - CHEVIE-name of the table: `3D4n2green`
 

--- a/data/Greenfunctions/3D4/3D4p2.jl
+++ b/data/Greenfunctions/3D4/3D4p2.jl
@@ -90,7 +90,7 @@ chardegree =
 
 information = raw"""The Green functions of $^3\mathrm{D}_4(2^n)$.
 
-- CHEVIE-name of the table: `3D4p2green`
+
 
 - The table was first computed in [Spa82*1](@cite).
 """

--- a/data/Greenfunctions/3D4/3D4p2.jl
+++ b/data/Greenfunctions/3D4/3D4p2.jl
@@ -90,8 +90,6 @@ chardegree =
 
 information = raw"""The Green functions of $^3\mathrm{D}_4(2^n)$.
 
-
-
 - The table was first computed in [Spa82*1](@cite).
 """
 

--- a/data/Greenfunctions/3D4/3D4p2.jl
+++ b/data/Greenfunctions/3D4/3D4p2.jl
@@ -88,7 +88,7 @@ chardegree =
     (q + 1)^2 * (q - 1)^2 * (q^2 - q + 1)^2 * (q^2 + q + 1)^2,
     (q^2 - q + 1) * (q^4 - q^2 + 1) * (q - 1)^2 * (q^2 + q + 1)^2])
 
-information = raw"""- Information about the Green functions of $^3\mathrm{D}_4(2^n)$.
+information = raw"""The Green functions of $^3\mathrm{D}_4(2^n)$.
 
 - CHEVIE-name of the table: `3D4p2green`
 

--- a/data/Greenfunctions/A0/GL1.jl
+++ b/data/Greenfunctions/A0/GL1.jl
@@ -13,7 +13,7 @@ chardegree = R.([1])
 
 information = raw"""The Green functions of $\mathrm{GL}_1(q)$.
 
-- CHEVIE-name of the table: `GL1green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A0/GL1.jl
+++ b/data/Greenfunctions/A0/GL1.jl
@@ -13,8 +13,6 @@ chardegree = R.([1])
 
 information = raw"""The Green functions of $\mathrm{GL}_1(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Greenfunctions/A0/GL1.jl
+++ b/data/Greenfunctions/A0/GL1.jl
@@ -11,7 +11,7 @@ classtypeorder = R.([1])
 charinfo = Vector{Any}[[[1]]]
 chardegree = R.([1])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_1(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_1(q)$.
 
 - CHEVIE-name of the table: `GL1green`
 

--- a/data/Greenfunctions/A0/GL1.jl
+++ b/data/Greenfunctions/A0/GL1.jl
@@ -27,7 +27,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A1/GL2.jl
+++ b/data/Greenfunctions/A1/GL2.jl
@@ -15,7 +15,7 @@ classtypeorder = R.([1, 1])
 charinfo = Vector{Any}[[[1, 1]], [[2]]]
 chardegree = R.([q + 1, 1 - q])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_2(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_2(q)$.
 
 - CHEVIE-name of the table: `GL2green`
 

--- a/data/Greenfunctions/A1/GL2.jl
+++ b/data/Greenfunctions/A1/GL2.jl
@@ -17,7 +17,7 @@ chardegree = R.([q + 1, 1 - q])
 
 information = raw"""The Green functions of $\mathrm{GL}_2(q)$.
 
-- CHEVIE-name of the table: `GL2green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A1/GL2.jl
+++ b/data/Greenfunctions/A1/GL2.jl
@@ -31,7 +31,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A1/GL2.jl
+++ b/data/Greenfunctions/A1/GL2.jl
@@ -17,8 +17,6 @@ chardegree = R.([q + 1, 1 - q])
 
 information = raw"""The Green functions of $\mathrm{GL}_2(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Greenfunctions/A10/GL11.jl
+++ b/data/Greenfunctions/A10/GL11.jl
@@ -7744,7 +7744,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_11(q)$.
 
-- CHEVIE-name of the table: `GL11green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A10/GL11.jl
+++ b/data/Greenfunctions/A10/GL11.jl
@@ -7742,7 +7742,7 @@ chardegree =
     (q^10 + q^9 + q^8 + q^7 + q^6 + q^5 + q^4 + q^3 + q^2 + q + 1) * (q^6 + q^3 + 1) *
     (q^4 + 1) * (q^2 + 1)^2 * (q^4 + q^3 + q^2 + q + 1)^2 * (q^2 + q + 1)^3 * (q + 1)^5])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_11(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_11(q)$.
 
 - CHEVIE-name of the table: `GL11green`
 

--- a/data/Greenfunctions/A10/GL11.jl
+++ b/data/Greenfunctions/A10/GL11.jl
@@ -7758,7 +7758,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A10/GL11.jl
+++ b/data/Greenfunctions/A10/GL11.jl
@@ -7744,8 +7744,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_11(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Greenfunctions/A2/GL3.jl
+++ b/data/Greenfunctions/A2/GL3.jl
@@ -23,7 +23,7 @@ chardegree = R.([(q + 1) * (q^2 + q + 1), -(q - 1) * (q^2 + q + 1), (q - 1)^2 * 
 
 information = raw"""The Green functions of $\mathrm{GL}_3(q)$.
 
-- CHEVIE-name of the table: `GL3green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A2/GL3.jl
+++ b/data/Greenfunctions/A2/GL3.jl
@@ -23,8 +23,6 @@ chardegree = R.([(q + 1) * (q^2 + q + 1), -(q - 1) * (q^2 + q + 1), (q - 1)^2 * 
 
 information = raw"""The Green functions of $\mathrm{GL}_3(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Greenfunctions/A2/GL3.jl
+++ b/data/Greenfunctions/A2/GL3.jl
@@ -21,7 +21,7 @@ classtypeorder = R.([1, 1, 1])
 charinfo = Vector{Any}[[[1, 1, 1]], [[2, 1]], [[3]]]
 chardegree = R.([(q + 1) * (q^2 + q + 1), -(q - 1) * (q^2 + q + 1), (q - 1)^2 * (q + 1)])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_3(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_3(q)$.
 
 - CHEVIE-name of the table: `GL3green`
 

--- a/data/Greenfunctions/A2/GL3.jl
+++ b/data/Greenfunctions/A2/GL3.jl
@@ -37,7 +37,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A3/GL4.jl
+++ b/data/Greenfunctions/A3/GL4.jl
@@ -64,7 +64,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A3/GL4.jl
+++ b/data/Greenfunctions/A3/GL4.jl
@@ -50,7 +50,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_4(q)$.
 
-- CHEVIE-name of the table: `GL4green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A3/GL4.jl
+++ b/data/Greenfunctions/A3/GL4.jl
@@ -50,8 +50,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_4(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Greenfunctions/A3/GL4.jl
+++ b/data/Greenfunctions/A3/GL4.jl
@@ -48,7 +48,7 @@ chardegree =
     (q^2 + 1) * (q - 1)^2 * (q + 1)^2,
     -(q + 1) * (q^2 + q + 1) * (q - 1)^3])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_4(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_4(q)$.
 
 - CHEVIE-name of the table: `GL4green`
 

--- a/data/Greenfunctions/A3;2/GL4e2.jl
+++ b/data/Greenfunctions/A3;2/GL4e2.jl
@@ -52,7 +52,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_4(2^n):2$.
 
-- CHEVIE-name of the table: `GL4e2green`
+
 
 - The table was first computed in [Mal93*1](@cite).
 """

--- a/data/Greenfunctions/A3;2/GL4e2.jl
+++ b/data/Greenfunctions/A3;2/GL4e2.jl
@@ -52,8 +52,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_4(2^n):2$.
 
-
-
 - The table was first computed in [Mal93*1](@cite).
 """
 

--- a/data/Greenfunctions/A3;2/GL4e2.jl
+++ b/data/Greenfunctions/A3;2/GL4e2.jl
@@ -50,7 +50,7 @@ chardegree =
     (q - 1)^2 * (q + 1)^2,
   ])
 
-information = raw"""- Information about the Green functions of $\mathrm{GL}_4(2^n):2$.
+information = raw"""The Green functions of $\mathrm{GL}_4(2^n):2$.
 
 - CHEVIE-name of the table: `GL4e2green`
 

--- a/data/Greenfunctions/A4/GL5.jl
+++ b/data/Greenfunctions/A4/GL5.jl
@@ -88,7 +88,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_5(q)$.
 
-- CHEVIE-name of the table: `GL5green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A4/GL5.jl
+++ b/data/Greenfunctions/A4/GL5.jl
@@ -102,7 +102,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A4/GL5.jl
+++ b/data/Greenfunctions/A4/GL5.jl
@@ -88,8 +88,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_5(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Greenfunctions/A4/GL5.jl
+++ b/data/Greenfunctions/A4/GL5.jl
@@ -86,7 +86,7 @@ chardegree =
     -(q + 1) * (q^2 + q + 1) * (q^4 + q^3 + q^2 + q + 1) * (q - 1)^3,
     (q^2 + q + 1) * (q^2 + 1) * (q + 1)^2 * (q - 1)^4])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_5(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_5(q)$.
 
 - CHEVIE-name of the table: `GL5green`
 

--- a/data/Greenfunctions/A4;2/GL5e2.jl
+++ b/data/Greenfunctions/A4;2/GL5e2.jl
@@ -64,8 +64,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_5(2^n):2$.
 
-
-
 - The table was first computed in [Mal93*1](@cite).
 """
 

--- a/data/Greenfunctions/A4;2/GL5e2.jl
+++ b/data/Greenfunctions/A4;2/GL5e2.jl
@@ -64,7 +64,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_5(2^n):2$.
 
-- CHEVIE-name of the table: `GL5e2green`
+
 
 - The table was first computed in [Mal93*1](@cite).
 """

--- a/data/Greenfunctions/A4;2/GL5e2.jl
+++ b/data/Greenfunctions/A4;2/GL5e2.jl
@@ -62,7 +62,7 @@ chardegree =
     (q - 1)^2 * (q + 1)^2,
   ])
 
-information = raw"""- Information about the Green functions of $\mathrm{GL}_5(2^n):2$.
+information = raw"""The Green functions of $\mathrm{GL}_5(2^n):2$.
 
 - CHEVIE-name of the table: `GL5e2green`
 

--- a/data/Greenfunctions/A5/GL6.jl
+++ b/data/Greenfunctions/A5/GL6.jl
@@ -197,7 +197,7 @@ chardegree =
     (q^2 + 1) * (q^2 - q + 1) * (q^2 + q + 1)^2 * (q + 1)^3 * (q - 1)^4,
     -(q^2 + q + 1) * (q^4 + q^3 + q^2 + q + 1) * (q^2 + 1) * (q + 1)^2 * (q - 1)^5])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_6(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_6(q)$.
 
 - CHEVIE-name of the table: `GL6green`
 

--- a/data/Greenfunctions/A5/GL6.jl
+++ b/data/Greenfunctions/A5/GL6.jl
@@ -199,7 +199,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_6(q)$.
 
-- CHEVIE-name of the table: `GL6green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A5/GL6.jl
+++ b/data/Greenfunctions/A5/GL6.jl
@@ -213,7 +213,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A5/GL6.jl
+++ b/data/Greenfunctions/A5/GL6.jl
@@ -199,8 +199,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_6(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Greenfunctions/A5;2/GL6e2.jl
+++ b/data/Greenfunctions/A5;2/GL6e2.jl
@@ -170,8 +170,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_6(2^n):2$.
 
-
-
 - The table was first computed in [Mal93*1](@cite).
 """
 

--- a/data/Greenfunctions/A5;2/GL6e2.jl
+++ b/data/Greenfunctions/A5;2/GL6e2.jl
@@ -170,7 +170,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_6(2^n):2$.
 
-- CHEVIE-name of the table: `GL6e2green`
+
 
 - The table was first computed in [Mal93*1](@cite).
 """

--- a/data/Greenfunctions/A5;2/GL6e2.jl
+++ b/data/Greenfunctions/A5;2/GL6e2.jl
@@ -168,7 +168,7 @@ chardegree =
     -(q - 1)^3 * (q + 1)^2 * (q^2 + q + 1) * (q^2 - q + 1),
     -(q - 1)^3 * (q + 1)^2 * (q^2 + q + 1) * (q^2 + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{GL}_6(2^n):2$.
+information = raw"""The Green functions of $\mathrm{GL}_6(2^n):2$.
 
 - CHEVIE-name of the table: `GL6e2green`
 

--- a/data/Greenfunctions/A6/GL7.jl
+++ b/data/Greenfunctions/A6/GL7.jl
@@ -372,7 +372,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A6/GL7.jl
+++ b/data/Greenfunctions/A6/GL7.jl
@@ -358,7 +358,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_7(q)$.
 
-- CHEVIE-name of the table: `GL7green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A6/GL7.jl
+++ b/data/Greenfunctions/A6/GL7.jl
@@ -356,7 +356,7 @@ chardegree =
     (q^2 - q + 1) * (q^4 + q^3 + q^2 + q + 1) * (q^2 + 1) * (q^2 + q + 1)^2 * (q + 1)^3 *
     (q - 1)^6])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_7(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_7(q)$.
 
 - CHEVIE-name of the table: `GL7green`
 

--- a/data/Greenfunctions/A6/GL7.jl
+++ b/data/Greenfunctions/A6/GL7.jl
@@ -358,8 +358,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_7(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Greenfunctions/A7/GL8.jl
+++ b/data/Greenfunctions/A7/GL8.jl
@@ -784,8 +784,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_8(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Greenfunctions/A7/GL8.jl
+++ b/data/Greenfunctions/A7/GL8.jl
@@ -784,7 +784,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_8(q)$.
 
-- CHEVIE-name of the table: `GL8green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A7/GL8.jl
+++ b/data/Greenfunctions/A7/GL8.jl
@@ -782,7 +782,7 @@ chardegree =
     -(q^2 - q + 1) * (q^4 + q^3 + q^2 + q + 1) * (q^6 + q^5 + q^4 + q^3 + q^2 + q + 1) *
     (q^2 + 1) * (q^2 + q + 1)^2 * (q + 1)^3 * (q - 1)^7])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_8(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_8(q)$.
 
 - CHEVIE-name of the table: `GL8green`
 

--- a/data/Greenfunctions/A7/GL8.jl
+++ b/data/Greenfunctions/A7/GL8.jl
@@ -798,7 +798,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A8/GL9.jl
+++ b/data/Greenfunctions/A8/GL9.jl
@@ -1609,7 +1609,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_9(q)$.
 
-- CHEVIE-name of the table: `GL9green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A8/GL9.jl
+++ b/data/Greenfunctions/A8/GL9.jl
@@ -1609,14 +1609,11 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_9(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
 
 - The program which generates the files with the Green functions 
   of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 

--- a/data/Greenfunctions/A8/GL9.jl
+++ b/data/Greenfunctions/A8/GL9.jl
@@ -1607,7 +1607,7 @@ chardegree =
     (q^6 + q^5 + q^4 + q^3 + q^2 + q + 1) * (q^2 + 1)^2 * (q^2 + q + 1)^2 * (q + 1)^4 *
     (q - 1)^8])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_9(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_9(q)$.
 
 - CHEVIE-name of the table: `GL9green`
 

--- a/data/Greenfunctions/A8/GL9.jl
+++ b/data/Greenfunctions/A8/GL9.jl
@@ -1624,7 +1624,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A9/GL10.jl
+++ b/data/Greenfunctions/A9/GL10.jl
@@ -3659,8 +3659,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_10(q)$.
 
-
-
 - These Green functions were introduced in: [Gre55](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Greenfunctions/A9/GL10.jl
+++ b/data/Greenfunctions/A9/GL10.jl
@@ -3657,7 +3657,7 @@ chardegree =
     (q^6 + q^5 + q^4 + q^3 + q^2 + q + 1) * (q^2 + 1)^2 * (q^2 + q + 1)^3 * (q + 1)^4 *
     (q - 1)^9])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{GL}_10(q)$.
+information = raw"""The Green functions of $\mathrm{GL}_10(q)$.
 
 - CHEVIE-name of the table: `GL10green`
 

--- a/data/Greenfunctions/A9/GL10.jl
+++ b/data/Greenfunctions/A9/GL10.jl
@@ -3659,7 +3659,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{GL}_10(q)$.
 
-- CHEVIE-name of the table: `GL10green`
+
 
 - These Green functions were introduced in: [Gre55](@cite).
 

--- a/data/Greenfunctions/A9/GL10.jl
+++ b/data/Greenfunctions/A9/GL10.jl
@@ -3673,7 +3673,7 @@ information = raw"""- Information about the tables of Green functions for $\math
   > GreenFunctionsA(n,filename);
   > GreenFunctions2A(n,filename);
   (see the corresponding help)
-  These programs are written by U. Porsch and F. Luebeck.
+  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/C2/C2n2.jl
+++ b/data/Greenfunctions/C2/C2n2.jl
@@ -51,7 +51,7 @@ chardegree =
     (q - 1)^2 * (q + 1)^2,
   ])
 
-information = raw"""- Information about the tables of Green functions for $\mathrm{CSp}_4(q)$, $q$ odd.
+information = raw"""The Green functions of $\mathrm{CSp}_4(q)$, $q$ odd.
 
 - CHEVIE-name of the table: `C2n2green`
 

--- a/data/Greenfunctions/C2/C2n2.jl
+++ b/data/Greenfunctions/C2/C2n2.jl
@@ -53,7 +53,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{CSp}_4(q)$, $q$ odd.
 
-- CHEVIE-name of the table: `C2n2green`
+
 
 - The generic character table of $\mathrm{CSp}_4(q)$, $q$ odd, and hence its Green 
   functions were computed in [Shi82](@cite).

--- a/data/Greenfunctions/C2/C2n2.jl
+++ b/data/Greenfunctions/C2/C2n2.jl
@@ -53,8 +53,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{CSp}_4(q)$, $q$ odd.
 
-
-
 - The generic character table of $\mathrm{CSp}_4(q)$, $q$ odd, and hence its Green 
   functions were computed in [Shi82](@cite).
 

--- a/data/Greenfunctions/C2/C2p2.jl
+++ b/data/Greenfunctions/C2/C2p2.jl
@@ -59,8 +59,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{Sp}_4(q)$, q even.
 
-
-
 - The table was first computed in [Eno72](@cite).
 
 - The names of the unipotent classes are taken from this paper.

--- a/data/Greenfunctions/C2/C2p2.jl
+++ b/data/Greenfunctions/C2/C2p2.jl
@@ -57,7 +57,7 @@ chardegree =
     (q - 1)^2 * (q + 1)^2,
   ])
 
-information = raw"""- Information about the Green functions of $\mathrm{Sp}_4(q)$, q even.
+information = raw"""The Green functions of $\mathrm{Sp}_4(q)$, q even.
 
 - CHEVIE-name of the table: `C2p2green`
 

--- a/data/Greenfunctions/C2/C2p2.jl
+++ b/data/Greenfunctions/C2/C2p2.jl
@@ -59,7 +59,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{Sp}_4(q)$, q even.
 
-- CHEVIE-name of the table: `C2p2green`
+
 
 - The table was first computed in [Eno72](@cite).
 

--- a/data/Greenfunctions/C3/C3n2.jl
+++ b/data/Greenfunctions/C3/C3n2.jl
@@ -155,7 +155,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{CSp}_6(q)$, $q$ odd.
 
-- CHEVIE-name of the table: `C3n2green`
+
 
 - These Green functions are computed in [LS90](@cite).
 """

--- a/data/Greenfunctions/C3/C3n2.jl
+++ b/data/Greenfunctions/C3/C3n2.jl
@@ -155,8 +155,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{CSp}_6(q)$, $q$ odd.
 
-
-
 - These Green functions are computed in [LS90](@cite).
 """
 

--- a/data/Greenfunctions/C3/C3n2.jl
+++ b/data/Greenfunctions/C3/C3n2.jl
@@ -153,7 +153,7 @@ chardegree =
     -(q - 1)^3 * (q + 1)^2 * (q^2 + q + 1) * (q^2 - q + 1),
     -(q - 1)^3 * (q + 1)^2 * (q^2 + q + 1) * (q^2 + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{CSp}_6(q)$, $q$ odd.
+information = raw"""The Green functions of $\mathrm{CSp}_6(q)$, $q$ odd.
 
 - CHEVIE-name of the table: `C3n2green`
 

--- a/data/Greenfunctions/C3/C3p2.jl
+++ b/data/Greenfunctions/C3/C3p2.jl
@@ -180,8 +180,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{Sp}_6(2^n)$.
 
-
-
 - The table was published in [Mal93](@cite).
 
 - The unipotent classes were determined in [Shi74](@cite).

--- a/data/Greenfunctions/C3/C3p2.jl
+++ b/data/Greenfunctions/C3/C3p2.jl
@@ -178,7 +178,7 @@ chardegree =
     -(q - 1)^3 * (q + 1)^2 * (q^2 + q + 1) * (q^2 - q + 1),
     -(q - 1)^3 * (q + 1)^2 * (q^2 + q + 1) * (q^2 + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{Sp}_6(2^n)$.
+information = raw"""The Green functions of $\mathrm{Sp}_6(2^n)$.
 
 - CHEVIE-name of the table: `C3p2green`
 

--- a/data/Greenfunctions/C3/C3p2.jl
+++ b/data/Greenfunctions/C3/C3p2.jl
@@ -180,7 +180,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{Sp}_6(2^n)$.
 
-- CHEVIE-name of the table: `C3p2green`
+
 
 - The table was published in [Mal93](@cite).
 

--- a/data/Greenfunctions/D4/D4p2.jl
+++ b/data/Greenfunctions/D4/D4p2.jl
@@ -251,7 +251,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{O}_8^+(q)$.
 
-- CHEVIE-name of the table: `D4p2green`
+
 
 - The table was published in [Mal93](@cite).
 

--- a/data/Greenfunctions/D4/D4p2.jl
+++ b/data/Greenfunctions/D4/D4p2.jl
@@ -249,7 +249,7 @@ chardegree =
     (q - 1)^4 * (q + 1)^4 * (q^2 + q + 1) * (q^2 - q + 1),
     (q - 1)^4 * (q + 1)^2 * (q^2 + q + 1) * (q^2 + 1)^2])
 
-information = raw"""- Information about the Green functions of $\mathrm{O}_8^+(q)$.
+information = raw"""The Green functions of $\mathrm{O}_8^+(q)$.
 
 - CHEVIE-name of the table: `D4p2green`
 

--- a/data/Greenfunctions/D4/D4p2.jl
+++ b/data/Greenfunctions/D4/D4p2.jl
@@ -251,8 +251,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{O}_8^+(q)$.
 
-
-
 - The table was published in [Mal93](@cite).
 
 - The notation for the unipotent classes is taken from [Spa82](@cite).

--- a/data/Greenfunctions/D4;2/D4e2.jl
+++ b/data/Greenfunctions/D4;2/D4e2.jl
@@ -156,8 +156,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{SO}_8^+(2^n)$.
 
-
-
 - The table was first computed in [Mal93*1](@cite).
 """
 

--- a/data/Greenfunctions/D4;2/D4e2.jl
+++ b/data/Greenfunctions/D4;2/D4e2.jl
@@ -154,7 +154,7 @@ chardegree =
     -(q - 1)^3 * (q + 1)^2 * (q^2 + q + 1) * (q^2 - q + 1),
     -(q - 1)^3 * (q + 1)^2 * (q^2 + q + 1) * (q^2 + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{SO}_8^+(2^n)$.
+information = raw"""The Green functions of $\mathrm{SO}_8^+(2^n)$.
 
 - CHEVIE-name of the table: `D4e2green`
 

--- a/data/Greenfunctions/D4;2/D4e2.jl
+++ b/data/Greenfunctions/D4;2/D4e2.jl
@@ -156,7 +156,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{SO}_8^+(2^n)$.
 
-- CHEVIE-name of the table: `D4e2green`
+
 
 - The table was first computed in [Mal93*1](@cite).
 """

--- a/data/Greenfunctions/D4;3/D4e3.jl
+++ b/data/Greenfunctions/D4;3/D4e3.jl
@@ -68,7 +68,7 @@ chardegree =
     (q - 1)^2 * (q + 1)^2 * (q^2 + q + 1),
     (q - 1)^2 * (q^2 + q + 1) * (q^2 - q + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{O}_8^+(3^n):3$.
+information = raw"""The Green functions of $\mathrm{O}_8^+(3^n):3$.
 
 - CHEVIE-name of the table: `D4e3green`
 

--- a/data/Greenfunctions/D4;3/D4e3.jl
+++ b/data/Greenfunctions/D4;3/D4e3.jl
@@ -70,8 +70,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{O}_8^+(3^n):3$.
 
-
-
 - The table was first computed in [Mal93*1](@cite).
 """
 

--- a/data/Greenfunctions/D4;3/D4e3.jl
+++ b/data/Greenfunctions/D4;3/D4e3.jl
@@ -70,7 +70,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{O}_8^+(3^n):3$.
 
-- CHEVIE-name of the table: `D4e3green`
+
 
 - The table was first computed in [Mal93*1](@cite).
 """

--- a/data/Greenfunctions/D5/D5p2.jl
+++ b/data/Greenfunctions/D5/D5p2.jl
@@ -507,7 +507,7 @@ chardegree =
     -(q - 1)^5 * (q + 1)^3 * (q^2 + q + 1) * (q^2 + 1) * (q^4 + q^3 + q^2 + q + 1) *
     (q^4 + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{O}_{10}^+(2^n)$.
+information = raw"""The Green functions of $\mathrm{O}_{10}^+(2^n)$.
 
 - CHEVIE-name of the table: `D5p2green`
 

--- a/data/Greenfunctions/D5/D5p2.jl
+++ b/data/Greenfunctions/D5/D5p2.jl
@@ -509,7 +509,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{O}_{10}^+(2^n)$.
 
-- CHEVIE-name of the table: `D5p2green`
+
 
 - The table was published in [Mal93](@cite).
 

--- a/data/Greenfunctions/D5/D5p2.jl
+++ b/data/Greenfunctions/D5/D5p2.jl
@@ -509,8 +509,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{O}_{10}^+(2^n)$.
 
-
-
 - The table was published in [Mal93](@cite).
 
 - The notation for the unipotent classes is taken from [Spa82](@cite).

--- a/data/Greenfunctions/E6/E6n23.jl
+++ b/data/Greenfunctions/E6/E6n23.jl
@@ -1024,7 +1024,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{E}_6(q)$, $p>3$.
 
-- CHEVIE-name of the table: `E6n23green`
+
 
 - The table was first computed in [BS84](@cite).
 """

--- a/data/Greenfunctions/E6/E6n23.jl
+++ b/data/Greenfunctions/E6/E6n23.jl
@@ -1022,7 +1022,7 @@ chardegree =
     -(q^2 + 1) * (q^4 + q^3 + q^2 + q + 1) * (q^2 - q + 1) * (q^4 + 1) * (q^4 - q^2 + 1) *
     (q^6 + q^3 + 1) * (q + 1)^3 * (q^2 + q + 1)^3 * (q - 1)^5])
 
-information = raw"""- Information about the Green functions of $\mathrm{E}_6(q)$, $p>3$.
+information = raw"""The Green functions of $\mathrm{E}_6(q)$, $p>3$.
 
 - CHEVIE-name of the table: `E6n23green`
 

--- a/data/Greenfunctions/E6/E6n23.jl
+++ b/data/Greenfunctions/E6/E6n23.jl
@@ -1024,8 +1024,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{E}_6(q)$, $p>3$.
 
-
-
 - The table was first computed in [BS84](@cite).
 """
 

--- a/data/Greenfunctions/E6/E6p2.jl
+++ b/data/Greenfunctions/E6/E6p2.jl
@@ -1127,8 +1127,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{E}_6(2^n)$.
 
-
-
 - The table was first computed in [Mal93](@cite).
 """
 

--- a/data/Greenfunctions/E6/E6p2.jl
+++ b/data/Greenfunctions/E6/E6p2.jl
@@ -1127,7 +1127,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{E}_6(2^n)$.
 
-- CHEVIE-name of the table: `E6p2green`
+
 
 - The table was first computed in [Mal93](@cite).
 """

--- a/data/Greenfunctions/E6/E6p2.jl
+++ b/data/Greenfunctions/E6/E6p2.jl
@@ -1125,7 +1125,7 @@ chardegree =
     -(q - 1)^5 * (q + 1)^3 * (q^2 + q + 1)^3 * (q^2 + 1) * (q^4 + q^3 + q^2 + q + 1) *
     (q^4 + 1) * (q^2 - q + 1) * (q^6 + q^3 + 1) * (q^4 - q^2 + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{E}_6(2^n)$.
+information = raw"""The Green functions of $\mathrm{E}_6(2^n)$.
 
 - CHEVIE-name of the table: `E6p2green`
 

--- a/data/Greenfunctions/E6/E6p3.jl
+++ b/data/Greenfunctions/E6/E6p3.jl
@@ -1096,11 +1096,7 @@ chardegree =
     -(q - 1)^5 * (q + 1)^3 * (q^2 + q + 1)^3 * (q^2 + 1) * (q^4 + q^3 + q^2 + q + 1) *
     (q^4 + 1) * (q^2 - q + 1) * (q^6 + q^3 + 1) * (q^4 - q^2 + 1)])
 
-information = raw"""The Green functions of $\mathrm{E}_6(3^n)$.
-
-
-
-"""
+information = raw"""The Green functions of $\mathrm{E}_6(3^n)$."""
 
 SimpleCharTable(
   order,

--- a/data/Greenfunctions/E6/E6p3.jl
+++ b/data/Greenfunctions/E6/E6p3.jl
@@ -1098,7 +1098,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{E}_6(3^n)$.
 
-- CHEVIE-name of the table: `E6p3green`
+
 
 """
 

--- a/data/Greenfunctions/E6/E6p3.jl
+++ b/data/Greenfunctions/E6/E6p3.jl
@@ -1096,7 +1096,7 @@ chardegree =
     -(q - 1)^5 * (q + 1)^3 * (q^2 + q + 1)^3 * (q^2 + 1) * (q^4 + q^3 + q^2 + q + 1) *
     (q^4 + 1) * (q^2 - q + 1) * (q^6 + q^3 + 1) * (q^4 - q^2 + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{E}_6(3^n)$.
+information = raw"""The Green functions of $\mathrm{E}_6(3^n)$.
 
 - CHEVIE-name of the table: `E6p3green`
 

--- a/data/Greenfunctions/E6;2/E6e2.jl
+++ b/data/Greenfunctions/E6;2/E6e2.jl
@@ -907,7 +907,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{E}_6(2^n):2$.
 
-- CHEVIE-name of the table: `E6e2green`
+
 
 - The table was first computed in [Mal93](@cite).
 

--- a/data/Greenfunctions/E6;2/E6e2.jl
+++ b/data/Greenfunctions/E6;2/E6e2.jl
@@ -907,8 +907,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{E}_6(2^n):2$.
 
-
-
 - The table was first computed in [Mal93](@cite).
 
 - The notation for the unipotent classes is as in that paper.

--- a/data/Greenfunctions/E6;2/E6e2.jl
+++ b/data/Greenfunctions/E6;2/E6e2.jl
@@ -905,7 +905,7 @@ chardegree =
     (q - 1)^4 * (q + 1)^4 * (q^2 + q + 1)^2 * (q^2 + 1)^2 * (q^2 - q + 1)^2 * (q^4 + 1),
     (q - 1)^4 * (q + 1)^4 * (q^2 + q + 1)^2 * (q^2 + 1)^2 * (q^4 + 1) * (q^4 - q^2 + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{E}_6(2^n):2$.
+information = raw"""The Green functions of $\mathrm{E}_6(2^n):2$.
 
 - CHEVIE-name of the table: `E6e2green`
 

--- a/data/Greenfunctions/F4/F4n23.jl
+++ b/data/Greenfunctions/F4/F4n23.jl
@@ -840,7 +840,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{F}_4(q)$, $p>3$.
 
-- CHEVIE-name of the table: `F4n23green`
+
 
 - The table was first computed in [Sho82](@cite).
 """

--- a/data/Greenfunctions/F4/F4n23.jl
+++ b/data/Greenfunctions/F4/F4n23.jl
@@ -838,7 +838,7 @@ chardegree =
     -(q - 1)^3 * (1 + q + q^2)^2 * (q + 1)^3 * (1 - q + q^2) * (q^2 + 1)^2 *
     (1 - q^2 + q^4) * (1 + q^4)])
 
-information = raw"""- Information about the Green functions of $\mathrm{F}_4(q)$, $p>3$.
+information = raw"""The Green functions of $\mathrm{F}_4(q)$, $p>3$.
 
 - CHEVIE-name of the table: `F4n23green`
 

--- a/data/Greenfunctions/F4/F4n23.jl
+++ b/data/Greenfunctions/F4/F4n23.jl
@@ -840,8 +840,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{F}_4(q)$, $p>3$.
 
-
-
 - The table was first computed in [Sho82](@cite).
 """
 

--- a/data/Greenfunctions/F4/F4p2.jl
+++ b/data/Greenfunctions/F4/F4p2.jl
@@ -1130,7 +1130,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{F}_4(2^n)$.
 
-- CHEVIE-name of the table: `F4p2green`
+
 
 - The table was first computed in [Mal93](@cite).
 

--- a/data/Greenfunctions/F4/F4p2.jl
+++ b/data/Greenfunctions/F4/F4p2.jl
@@ -1130,8 +1130,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{F}_4(2^n)$.
 
-
-
 - The table was first computed in [Mal93](@cite).
 
 - The unipotent classes were determined in [Shi74](@cite).

--- a/data/Greenfunctions/F4/F4p2.jl
+++ b/data/Greenfunctions/F4/F4p2.jl
@@ -1128,7 +1128,7 @@ chardegree =
     (q - 1)^4 * (q + 1)^4 * (q^2 + q + 1)^2 * (q^2 + 1)^2 * (q^2 - q + 1)^2 * (q^4 + 1),
     (q - 1)^4 * (q + 1)^4 * (q^2 + q + 1)^2 * (q^2 + 1)^2 * (q^4 + 1) * (q^4 - q^2 + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{F}_4(2^n)$.
+information = raw"""The Green functions of $\mathrm{F}_4(2^n)$.
 
 - CHEVIE-name of the table: `F4p2green`
 

--- a/data/Greenfunctions/G2/G2n23.jl
+++ b/data/Greenfunctions/G2/G2n23.jl
@@ -70,7 +70,7 @@ chardegree =
     (q - 1)^2 * (q + 1)^2 * (q^2 - q + 1),
     (q - 1)^2 * (q^2 + q + 1) * (q^2 - q + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{G}_2(q)$, $p>3$.
+information = raw"""The Green functions of $\mathrm{G}_2(q)$, $p>3$.
 
 - CHEVIE-name of the table: `G2n23green`
 

--- a/data/Greenfunctions/G2/G2n23.jl
+++ b/data/Greenfunctions/G2/G2n23.jl
@@ -72,8 +72,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{G}_2(q)$, $p>3$.
 
-
-
 - The table was first computed in [CR74](@cite).
 
   The notation for the unipotent classes is taken from that paper.

--- a/data/Greenfunctions/G2/G2n23.jl
+++ b/data/Greenfunctions/G2/G2n23.jl
@@ -72,7 +72,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{G}_2(q)$, $p>3$.
 
-- CHEVIE-name of the table: `G2n23green`
+
 
 - The table was first computed in [CR74](@cite).
 

--- a/data/Greenfunctions/G2/G2p2.jl
+++ b/data/Greenfunctions/G2/G2p2.jl
@@ -81,8 +81,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{G}_2(2^n)$.
 
-
-
 - The table was first computed in [EY86](@cite).
 
   The notation for the unipotent classes is taken from that paper.

--- a/data/Greenfunctions/G2/G2p2.jl
+++ b/data/Greenfunctions/G2/G2p2.jl
@@ -79,7 +79,7 @@ chardegree =
     (q - 1)^2 * (q + 1)^2 * (q^2 - q + 1),
     (q - 1)^2 * (q^2 + q + 1) * (q^2 - q + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{G}_2(2^n)$.
+information = raw"""The Green functions of $\mathrm{G}_2(2^n)$.
 
 - CHEVIE-name of the table: `G2p2green`
 

--- a/data/Greenfunctions/G2/G2p2.jl
+++ b/data/Greenfunctions/G2/G2p2.jl
@@ -81,7 +81,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{G}_2(2^n)$.
 
-- CHEVIE-name of the table: `G2p2green`
+
 
 - The table was first computed in [EY86](@cite).
 

--- a/data/Greenfunctions/G2/G2p3.jl
+++ b/data/Greenfunctions/G2/G2p3.jl
@@ -94,7 +94,7 @@ chardegree =
     (q - 1)^2 * (q + 1)^2 * (q^2 - q + 1),
     (q - 1)^2 * (q^2 + q + 1) * (q^2 - q + 1)])
 
-information = raw"""- Information about the Green functions of $\mathrm{G}_2(3^n)$.
+information = raw"""The Green functions of $\mathrm{G}_2(3^n)$.
 
 - CHEVIE-name of the table: `G2p3green`
 

--- a/data/Greenfunctions/G2/G2p3.jl
+++ b/data/Greenfunctions/G2/G2p3.jl
@@ -96,8 +96,6 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{G}_2(3^n)$.
 
-
-
 - The table was first computed in [Eno76](@cite).
 
   The notation for the unipotent classes is taken from that paper.

--- a/data/Greenfunctions/G2/G2p3.jl
+++ b/data/Greenfunctions/G2/G2p3.jl
@@ -96,7 +96,7 @@ chardegree =
 
 information = raw"""The Green functions of $\mathrm{G}_2(3^n)$.
 
-- CHEVIE-name of the table: `G2p3green`
+
 
 - The table was first computed in [Eno76](@cite).
 

--- a/data/Tables/2A2/GU3.jl
+++ b/data/Tables/2A2/GU3.jl
@@ -324,7 +324,7 @@ charparamindex = var_index.([u, v, w])
 
 information = raw"""The generic character table of $\mathrm{GU}_3(q)$.
 
-- CHEVIE-name of the table: `GU3`
+
 
 - The table was first computed in: [Enn63](@cite).
 

--- a/data/Tables/2A2/GU3.jl
+++ b/data/Tables/2A2/GU3.jl
@@ -322,7 +322,7 @@ charparams = [
 classparamindex = var_index.([k, l, m])
 charparamindex = var_index.([u, v, w])
 
-information = raw"""- Information about the generic character table of $\mathrm{GU}_3(q)$.
+information = raw"""The generic character table of $\mathrm{GU}_3(q)$.
 
 - CHEVIE-name of the table: `GU3`
 

--- a/data/Tables/2A2/GU3.jl
+++ b/data/Tables/2A2/GU3.jl
@@ -324,8 +324,6 @@ charparamindex = var_index.([u, v, w])
 
 information = raw"""The generic character table of $\mathrm{GU}_3(q)$.
 
-
-
 - The table was first computed in: [Enn63](@cite).
 
 - See also: [Enn62](@cite).

--- a/data/Tables/2A2/PGU3.2.jl
+++ b/data/Tables/2A2/PGU3.2.jl
@@ -300,7 +300,7 @@ information = raw"""The generic character table of $\mathrm{PGU}_3(q)$,
   (See `SU3.n2` for the generic character table of $\mathrm{PGU}_3(q)$,
   $q$ not congruent to $2$ modulo $3$.)
 
-- CHEVIE-name of the table: `PGU3.2`
+
 
 - The table was derived by Meinolf Geck from: [Enn63](@cite).
 

--- a/data/Tables/2A2/PGU3.2.jl
+++ b/data/Tables/2A2/PGU3.2.jl
@@ -295,7 +295,7 @@ charparams = [
 classparamindex = var_index.([k, l])
 charparamindex = var_index.([u, v])
 
-information = raw"""- Information about the generic character table of $\mathrm{PGU}_3(q)$,
+information = raw"""The generic character table of $\mathrm{PGU}_3(q)$,
   $q$ congruent to $2$ modulo $3$.
   (See `SU3.n2` for the generic character table of $\mathrm{PGU}_3(q)$,
   $q$ not congruent to $2$ modulo $3$.)

--- a/data/Tables/2A2/PGU3.2.jl
+++ b/data/Tables/2A2/PGU3.2.jl
@@ -300,8 +300,6 @@ information = raw"""The generic character table of $\mathrm{PGU}_3(q)$,
   (See `SU3.n2` for the generic character table of $\mathrm{PGU}_3(q)$,
   $q$ not congruent to $2$ modulo $3$.)
 
-
-
 - The table was derived by Meinolf Geck from: [Enn63](@cite).
 
 - See also: [Enn62](@cite).

--- a/data/Tables/2A2/PSU3.2.jl
+++ b/data/Tables/2A2/PSU3.2.jl
@@ -368,8 +368,6 @@ information = raw"""The generic character table of $\mathrm{PSU}_3(q)$,
   (See `SU3.n2` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ not congruent to $2$ modulo $3$.)
 
-
-
 - The table was first computed in [SF73](@cite).
 
 - The table was constructed by Jochen Gruber from the generic character

--- a/data/Tables/2A2/PSU3.2.jl
+++ b/data/Tables/2A2/PSU3.2.jl
@@ -368,7 +368,7 @@ information = raw"""The generic character table of $\mathrm{PSU}_3(q)$,
   (See `SU3.n2` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ not congruent to $2$ modulo $3$.)
 
-- CHEVIE-name of the table: `PSU3.2`
+
 
 - The table was first computed in [SF73](@cite).
 

--- a/data/Tables/2A2/PSU3.2.jl
+++ b/data/Tables/2A2/PSU3.2.jl
@@ -363,7 +363,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([m, n])
 
-information = raw"""- Information about the generic character table of $\mathrm{PSU}_3(q)$,
+information = raw"""The generic character table of $\mathrm{PSU}_3(q)$,
   $q$ congruent to $2$ modulo $3$
   (See `SU3.n2` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ not congruent to $2$ modulo $3$.)

--- a/data/Tables/2A2/SU3.2.jl
+++ b/data/Tables/2A2/SU3.2.jl
@@ -432,8 +432,6 @@ information = raw"""The generic character table of $\mathrm{SU}_3(q)$,
   (See `SU3.n2` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ not congruent to $2$ modulo $3$.)
 
-
-
 - The table was first computed in [SF73](@cite).
 
 - Corrections in [Gec90](@cite).

--- a/data/Tables/2A2/SU3.2.jl
+++ b/data/Tables/2A2/SU3.2.jl
@@ -427,7 +427,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([m, n])
 
-information = raw"""- Information about the generic character table of $\mathrm{SU}_3(q)$,
+information = raw"""The generic character table of $\mathrm{SU}_3(q)$,
   $q$ congruent to $2$ modulo $3$
   (See `SU3.n2` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ not congruent to $2$ modulo $3$.)

--- a/data/Tables/2A2/SU3.2.jl
+++ b/data/Tables/2A2/SU3.2.jl
@@ -432,7 +432,7 @@ information = raw"""The generic character table of $\mathrm{SU}_3(q)$,
   (See `SU3.n2` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ not congruent to $2$ modulo $3$.)
 
-- CHEVIE-name of the table: `SU3.2`
+
 
 - The table was first computed in [SF73](@cite).
 

--- a/data/Tables/2A2/SU3.n2.jl
+++ b/data/Tables/2A2/SU3.n2.jl
@@ -250,7 +250,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([m, n])
 
-information = raw"""- Information about the generic character table of $\mathrm{SU}_3(q)$,
+information = raw"""The generic character table of $\mathrm{SU}_3(q)$,
   $q$ not congruent to $2$ modulo $3$
   (See `SU3.2` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ congruent to $2$ modulo $3$.)

--- a/data/Tables/2A2/SU3.n2.jl
+++ b/data/Tables/2A2/SU3.n2.jl
@@ -259,8 +259,6 @@ information = raw"""The generic character table of $\mathrm{SU}_3(q)$,
   The three groups $\mathrm{SU}_3(q)$, $\mathrm{PGU}_3(q)$ and $\mathrm{PSU}_3(q)$ are
   mutually isomorphic for these values of $q$.
 
-
-
 - The table was first computed in [SF73](@cite).
 
 - Corrections in [Gec90](@cite).

--- a/data/Tables/2A2/SU3.n2.jl
+++ b/data/Tables/2A2/SU3.n2.jl
@@ -259,7 +259,7 @@ information = raw"""The generic character table of $\mathrm{SU}_3(q)$,
   The three groups $\mathrm{SU}_3(q)$, $\mathrm{PGU}_3(q)$ and $\mathrm{PSU}_3(q)$ are
   mutually isomorphic for these values of $q$.
 
-- CHEVIE-name of the table: `SU3.n2`
+
 
 - The table was first computed in [SF73](@cite).
 

--- a/data/Tables/2B2/2B2.jl
+++ b/data/Tables/2B2/2B2.jl
@@ -208,7 +208,7 @@ charparamindex = var_index.([s, k, u])
 information = raw"""The generic character table of $^2\mathrm{B}_2(q^2)$,
   where $q = \sqrt{2}q_0$.
 
-- CHEVIE-name of the table: `Sz`
+
 
 - The table was first computed in [Suz62](@cite).
 """

--- a/data/Tables/2B2/2B2.jl
+++ b/data/Tables/2B2/2B2.jl
@@ -205,7 +205,7 @@ charparams = [
 classparamindex = var_index.([a, b, c])
 charparamindex = var_index.([s, k, u])
 
-information = raw"""- Information about the generic character table of $^2\mathrm{B}_2(q^2)$,
+information = raw"""The generic character table of $^2\mathrm{B}_2(q^2)$,
   where $q = \sqrt{2}q_0$.
 
 - CHEVIE-name of the table: `Sz`

--- a/data/Tables/2B2/2B2.jl
+++ b/data/Tables/2B2/2B2.jl
@@ -208,8 +208,6 @@ charparamindex = var_index.([s, k, u])
 information = raw"""The generic character table of $^2\mathrm{B}_2(q^2)$,
   where $q = \sqrt{2}q_0$.
 
-
-
 - The table was first computed in [Suz62](@cite).
 """
 

--- a/data/Tables/2D4/uni2D4.0.jl
+++ b/data/Tables/2D4/uni2D4.0.jl
@@ -883,7 +883,7 @@ chardegree =
 information = raw"""The unipotent characters of $\mathrm{CO}_8^-(q)$,
   with even q.
 
-- CHEVIE-name of the table: `uni2D4.0`
+
 
 - This table was computed by F. Lübeck, most of it with general programs.
 """

--- a/data/Tables/2D4/uni2D4.0.jl
+++ b/data/Tables/2D4/uni2D4.0.jl
@@ -880,7 +880,7 @@ chardegree =
     q * (q^4 + 1),
     1])
 
-information = raw"""- Information about the generic table of unipotent characters of $\mathrm{CO}_8^-(q)$,
+information = raw"""The unipotent characters of $\mathrm{CO}_8^-(q)$,
   with even q.
 
 - CHEVIE-name of the table: `uni2D4.0`

--- a/data/Tables/2D4/uni2D4.0.jl
+++ b/data/Tables/2D4/uni2D4.0.jl
@@ -885,7 +885,7 @@ information = raw"""- Information about the generic table of unipotent character
 
 - CHEVIE-name of the table: `uni2D4.0`
 
-- This table was computed by F.Luebeck, most of it with general programs.
+- This table was computed by F. Lübeck, most of it with general programs.
 """
 
 SimpleCharTable(

--- a/data/Tables/2D4/uni2D4.0.jl
+++ b/data/Tables/2D4/uni2D4.0.jl
@@ -883,8 +883,6 @@ chardegree =
 information = raw"""The unipotent characters of $\mathrm{CO}_8^-(q)$,
   with even q.
 
-
-
 - This table was computed by F. Lübeck, most of it with general programs.
 """
 

--- a/data/Tables/2D4/uni2D4.1.jl
+++ b/data/Tables/2D4/uni2D4.1.jl
@@ -1027,7 +1027,7 @@ chardegree =
 information = raw"""The unipotent characters of $\mathrm{CO}_8^-(q)$,
   with odd q.
 
-- CHEVIE-name of the table: `uni2D4.1`
+
 
 - This table was computed by F. Lübeck, most of it with general programs.
 """

--- a/data/Tables/2D4/uni2D4.1.jl
+++ b/data/Tables/2D4/uni2D4.1.jl
@@ -1029,7 +1029,7 @@ information = raw"""- Information about the generic table of unipotent character
 
 - CHEVIE-name of the table: `uni2D4.1`
 
-- This table was computed by F.Luebeck, most of it with general programs.
+- This table was computed by F. Lübeck, most of it with general programs.
 """
 
 SimpleCharTable(

--- a/data/Tables/2D4/uni2D4.1.jl
+++ b/data/Tables/2D4/uni2D4.1.jl
@@ -1027,8 +1027,6 @@ chardegree =
 information = raw"""The unipotent characters of $\mathrm{CO}_8^-(q)$,
   with odd q.
 
-
-
 - This table was computed by F. Lübeck, most of it with general programs.
 """
 

--- a/data/Tables/2D4/uni2D4.1.jl
+++ b/data/Tables/2D4/uni2D4.1.jl
@@ -1024,7 +1024,7 @@ chardegree =
     q * (q^4 + 1),
     1])
 
-information = raw"""- Information about the generic table of unipotent characters of $\mathrm{CO}_8^-(q)$,
+information = raw"""The unipotent characters of $\mathrm{CO}_8^-(q)$,
   with odd q.
 
 - CHEVIE-name of the table: `uni2D4.1`

--- a/data/Tables/2F4/2F4.1.jl
+++ b/data/Tables/2F4/2F4.1.jl
@@ -3830,7 +3830,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $^2\mathrm{F}_4(q^2)$,
+information = raw"""The generic character table of $^2\mathrm{F}_4(q^2)$,
   where $\frac{q}{\sqrt{2}} = q_0$ is congruent to $1$ modulo $3$.
 
 - CHEVIE-name of the table: `Ree`

--- a/data/Tables/2F4/2F4.1.jl
+++ b/data/Tables/2F4/2F4.1.jl
@@ -3833,8 +3833,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $^2\mathrm{F}_4(q^2)$,
   where $\frac{q}{\sqrt{2}} = q_0$ is congruent to $1$ modulo $3$.
 
-
-
 - The unipotent characters were first computed in [Mal90](@cite).
 
 - The other irreducible characters were added by G. Malle

--- a/data/Tables/2F4/2F4.1.jl
+++ b/data/Tables/2F4/2F4.1.jl
@@ -3833,7 +3833,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $^2\mathrm{F}_4(q^2)$,
   where $\frac{q}{\sqrt{2}} = q_0$ is congruent to $1$ modulo $3$.
 
-- CHEVIE-name of the table: `Ree`
+
 
 - The unipotent characters were first computed in [Mal90](@cite).
 

--- a/data/Tables/2F4/2F4.2.jl
+++ b/data/Tables/2F4/2F4.2.jl
@@ -3830,7 +3830,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $^2\mathrm{F}_4(q^2)$,
+information = raw"""The generic character table of $^2\mathrm{F}_4(q^2)$,
   where $\frac{q}{\sqrt{2}} = q_0$ is congruent to $2$ modulo $3$.
 
 - CHEVIE-name of the table: `Ree`

--- a/data/Tables/2F4/2F4.2.jl
+++ b/data/Tables/2F4/2F4.2.jl
@@ -3833,8 +3833,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $^2\mathrm{F}_4(q^2)$,
   where $\frac{q}{\sqrt{2}} = q_0$ is congruent to $2$ modulo $3$.
 
-
-
 - The unipotent characters were first computed in [Mal90](@cite).
 
 - The other irreducible characters were added by G. Malle

--- a/data/Tables/2F4/2F4.2.jl
+++ b/data/Tables/2F4/2F4.2.jl
@@ -3833,7 +3833,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $^2\mathrm{F}_4(q^2)$,
   where $\frac{q}{\sqrt{2}} = q_0$ is congruent to $2$ modulo $3$.
 
-- CHEVIE-name of the table: `Ree`
+
 
 - The unipotent characters were first computed in [Mal90](@cite).
 

--- a/data/Tables/2G2/2G2.jl
+++ b/data/Tables/2G2/2G2.jl
@@ -493,7 +493,7 @@ information = raw"""- Information about the generic character table of the Ree g
 - Most of the table was determined in [War66](@cite).
 
 - The values of the irreducible Deligne-Lusztig characters were
-  computed by F.Luebeck.
+  computed by F. Lübeck.
 
 - The names of class types and character types used in the above
   cited article can be recovered as fourths components of the 

--- a/data/Tables/2G2/2G2.jl
+++ b/data/Tables/2G2/2G2.jl
@@ -488,7 +488,7 @@ information = raw"""The generic character table of the Ree groups
   $q^2 = 3^{2m+1}$ with m a non negative integer. So
   $q = \sqrt{3}q_0$ where $q_0 = 3^m$.
 
-- CHEVIE-name of the table: `ree`
+
 
 - Most of the table was determined in [War66](@cite).
 

--- a/data/Tables/2G2/2G2.jl
+++ b/data/Tables/2G2/2G2.jl
@@ -483,7 +483,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of the Ree groups
+information = raw"""The generic character table of the Ree groups
   $^2\mathrm{G}_2(q)$. The possible values for $q$ are given by
   $q^2 = 3^{2m+1}$ with m a non negative integer. So
   $q = \sqrt{3}q_0$ where $q_0 = 3^m$.

--- a/data/Tables/2G2/2G2.jl
+++ b/data/Tables/2G2/2G2.jl
@@ -485,7 +485,7 @@ charparamindex = var_index.([k, l])
 
 information = raw"""- Information about the generic character table of the Ree groups
   $^2\mathrm{G}_2(q)$. The possible values for $q$ are given by
-  $q^2 = 3^{2*m+1}$ with m a non negative integer. So
+  $q^2 = 3^{2m+1}$ with m a non negative integer. So
   $q = \sqrt{3}q_0$ where $q_0 = 3^m$.
 
 - CHEVIE-name of the table: `ree`

--- a/data/Tables/2G2/2G2.jl
+++ b/data/Tables/2G2/2G2.jl
@@ -488,8 +488,6 @@ information = raw"""The generic character table of the Ree groups
   $q^2 = 3^{2m+1}$ with m a non negative integer. So
   $q = \sqrt{3}q_0$ where $q_0 = 3^m$.
 
-
-
 - Most of the table was determined in [War66](@cite).
 
 - The values of the irreducible Deligne-Lusztig characters were

--- a/data/Tables/3D4/3D4.0.jl
+++ b/data/Tables/3D4/3D4.0.jl
@@ -1837,7 +1837,7 @@ charparamindex = var_index.([k, l])
 
 information = raw"""The generic character table of $^3\mathrm{D}_4(2^n)$.
 
-- CHEVIE-name of the table: `3D4.0`
+
 
 - The table was first computed in [DM87](@cite).
 """

--- a/data/Tables/3D4/3D4.0.jl
+++ b/data/Tables/3D4/3D4.0.jl
@@ -1837,8 +1837,6 @@ charparamindex = var_index.([k, l])
 
 information = raw"""The generic character table of $^3\mathrm{D}_4(2^n)$.
 
-
-
 - The table was first computed in [DM87](@cite).
 """
 

--- a/data/Tables/3D4/3D4.0.jl
+++ b/data/Tables/3D4/3D4.0.jl
@@ -1835,7 +1835,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $^3\mathrm{D}_4(2^n)$.
+information = raw"""The generic character table of $^3\mathrm{D}_4(2^n)$.
 
 - CHEVIE-name of the table: `3D4.0`
 

--- a/data/Tables/3D4/3D4.11.jl
+++ b/data/Tables/3D4/3D4.11.jl
@@ -2188,8 +2188,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $^3\mathrm{D}_4(q)$,
   $p>2$, congruent to $1$ modulo $4$.
 
-
-
 - The table was first computed in [DM87](@cite).
 """
 

--- a/data/Tables/3D4/3D4.11.jl
+++ b/data/Tables/3D4/3D4.11.jl
@@ -2185,7 +2185,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $^3\mathrm{D}_4(q)$,
+information = raw"""The generic character table of $^3\mathrm{D}_4(q)$,
   $p>2$, congruent to $1$ modulo $4$.
 
 - CHEVIE-name of the table: `3D4.1`

--- a/data/Tables/3D4/3D4.11.jl
+++ b/data/Tables/3D4/3D4.11.jl
@@ -2188,7 +2188,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $^3\mathrm{D}_4(q)$,
   $p>2$, congruent to $1$ modulo $4$.
 
-- CHEVIE-name of the table: `3D4.1`
+
 
 - The table was first computed in [DM87](@cite).
 """

--- a/data/Tables/3D4/3D4.13.jl
+++ b/data/Tables/3D4/3D4.13.jl
@@ -2185,7 +2185,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $^3\mathrm{D}_4(q)$,
+information = raw"""The generic character table of $^3\mathrm{D}_4(q)$,
   $p>2$, congruent to $3$ modulo $4$.
 
 - CHEVIE-name of the table: `3D4.1`

--- a/data/Tables/3D4/3D4.13.jl
+++ b/data/Tables/3D4/3D4.13.jl
@@ -2188,8 +2188,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $^3\mathrm{D}_4(q)$,
   $p>2$, congruent to $3$ modulo $4$.
 
-
-
 - The table was first computed in [DM87](@cite).
 """
 

--- a/data/Tables/3D4/3D4.13.jl
+++ b/data/Tables/3D4/3D4.13.jl
@@ -2188,7 +2188,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $^3\mathrm{D}_4(q)$,
   $p>2$, congruent to $3$ modulo $4$.
 
-- CHEVIE-name of the table: `3D4.1`
+
 
 - The table was first computed in [DM87](@cite).
 """

--- a/data/Tables/A1/GL2.jl
+++ b/data/Tables/A1/GL2.jl
@@ -131,8 +131,6 @@ charparamindex = var_index.([l, k])
 
 information = raw"""The generic character table of $\mathrm{GL}_2(q)$.
 
-
-
 - The table was first computed in [Jor07](@cite), [Sch07](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Tables/A1/GL2.jl
+++ b/data/Tables/A1/GL2.jl
@@ -131,7 +131,7 @@ charparamindex = var_index.([l, k])
 
 information = raw"""The generic character table of $\mathrm{GL}_2(q)$.
 
-- CHEVIE-name of the table: `GL2`
+
 
 - The table was first computed in [Jor07](@cite), [Sch07](@cite).
 

--- a/data/Tables/A1/GL2.jl
+++ b/data/Tables/A1/GL2.jl
@@ -129,7 +129,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([l, k])
 
-information = raw"""- Information about the generic character table of $\mathrm{GL}_2(q)$.
+information = raw"""The generic character table of $\mathrm{GL}_2(q)$.
 
 - CHEVIE-name of the table: `GL2`
 

--- a/data/Tables/A1/GU2.jl
+++ b/data/Tables/A1/GU2.jl
@@ -135,7 +135,7 @@ charparams = [
 classparamindex = var_index.([k, l])
 charparamindex = var_index.([u, v])
 
-information = raw"""- Information about the generic character table of $\mathrm{GU}_2(q)$.
+information = raw"""The generic character table of $\mathrm{GU}_2(q)$.
 
 - CHEVIE-name of the table: `GU2`
 

--- a/data/Tables/A1/GU2.jl
+++ b/data/Tables/A1/GU2.jl
@@ -137,7 +137,7 @@ charparamindex = var_index.([u, v])
 
 information = raw"""The generic character table of $\mathrm{GU}_2(q)$.
 
-- CHEVIE-name of the table: `GU2`
+
 
 - The table was first computed in [Enn63](@cite).
 

--- a/data/Tables/A1/GU2.jl
+++ b/data/Tables/A1/GU2.jl
@@ -137,8 +137,6 @@ charparamindex = var_index.([u, v])
 
 information = raw"""The generic character table of $\mathrm{GU}_2(q)$.
 
-
-
 - The table was first computed in [Enn63](@cite).
 
 - See also: [Enn62](@cite).

--- a/data/Tables/A1/PGL2.1.jl
+++ b/data/Tables/A1/PGL2.1.jl
@@ -135,7 +135,7 @@ charparamindex = var_index.([l, k])
 information = raw"""The generic character table of $\mathrm{PGL}_2(q)$, $q$ odd
   (See `SL2.0` for the generic character table of $\mathrm{PGL}_2(q)$, $q$ even)
 
-- CHEVIE-name of the table: `PGL2.1`
+
 
 - The table was first computed in [Jor07](@cite), [Sch07](@cite).
 

--- a/data/Tables/A1/PGL2.1.jl
+++ b/data/Tables/A1/PGL2.1.jl
@@ -135,8 +135,6 @@ charparamindex = var_index.([l, k])
 information = raw"""The generic character table of $\mathrm{PGL}_2(q)$, $q$ odd
   (See `SL2.0` for the generic character table of $\mathrm{PGL}_2(q)$, $q$ even)
 
-
-
 - The table was first computed in [Jor07](@cite), [Sch07](@cite).
 
 - See also: [Ste51](@cite).

--- a/data/Tables/A1/PGL2.1.jl
+++ b/data/Tables/A1/PGL2.1.jl
@@ -132,7 +132,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([l, k])
 
-information = raw"""- Information about the generic character table of $\mathrm{PGL}_2(q)$, $q$ odd
+information = raw"""The generic character table of $\mathrm{PGL}_2(q)$, $q$ odd
   (See `SL2.0` for the generic character table of $\mathrm{PGL}_2(q)$, $q$ even)
 
 - CHEVIE-name of the table: `PGL2.1`

--- a/data/Tables/A1/PSL2.1.jl
+++ b/data/Tables/A1/PSL2.1.jl
@@ -126,7 +126,7 @@ charparams = [
 classparamindex = var_index.([i])
 charparamindex = var_index.([k])
 
-information = raw"""- Information about the generic character table of $\mathrm{PSL}_2(q^2)$,
+information = raw"""The generic character table of $\mathrm{PSL}_2(q^2)$,
   $q^2$ congruent to $1$ modulo $4$. The possible values for q are given by
   $q^2 = p^m$ with m a non negative integer and $p$ a prime number.
 

--- a/data/Tables/A1/PSL2.1.jl
+++ b/data/Tables/A1/PSL2.1.jl
@@ -130,7 +130,7 @@ information = raw"""The generic character table of $\mathrm{PSL}_2(q^2)$,
   $q^2$ congruent to $1$ modulo $4$. The possible values for q are given by
   $q^2 = p^m$ with m a non negative integer and $p$ a prime number.
 
-- CHEVIE-name of the table: `PSL2.1`
+
 
 - The table was first (implicitly) computed in [Fro96](@cite).
 

--- a/data/Tables/A1/PSL2.1.jl
+++ b/data/Tables/A1/PSL2.1.jl
@@ -130,8 +130,6 @@ information = raw"""The generic character table of $\mathrm{PSL}_2(q^2)$,
   $q^2$ congruent to $1$ modulo $4$. The possible values for q are given by
   $q^2 = p^m$ with m a non negative integer and $p$ a prime number.
 
-
-
 - The table was first (implicitly) computed in [Fro96](@cite).
 
 - See also: [Sch07](@cite).

--- a/data/Tables/A1/PSL2.3.jl
+++ b/data/Tables/A1/PSL2.3.jl
@@ -126,7 +126,7 @@ charparams = [
 classparamindex = var_index.([i])
 charparamindex = var_index.([k])
 
-information = raw"""- Information about the generic character table of $\mathrm{PSL}_2(q^2)$,
+information = raw"""The generic character table of $\mathrm{PSL}_2(q^2)$,
   $q^2$ congruent to $3$ modulo $4$. The possible values for q are given by
   $q^2 = p^m$ with m a non negative integer and $p$ a prime number.
 

--- a/data/Tables/A1/PSL2.3.jl
+++ b/data/Tables/A1/PSL2.3.jl
@@ -130,8 +130,6 @@ information = raw"""The generic character table of $\mathrm{PSL}_2(q^2)$,
   $q^2$ congruent to $3$ modulo $4$. The possible values for q are given by
   $q^2 = p^m$ with m a non negative integer and $p$ a prime number.
 
-
-
 - The table was first (implicitly) computed in [Fro96](@cite).
 
 - See also: [Sch07](@cite).

--- a/data/Tables/A1/PSL2.3.jl
+++ b/data/Tables/A1/PSL2.3.jl
@@ -130,7 +130,7 @@ information = raw"""The generic character table of $\mathrm{PSL}_2(q^2)$,
   $q^2$ congruent to $3$ modulo $4$. The possible values for q are given by
   $q^2 = p^m$ with m a non negative integer and $p$ a prime number.
 
-- CHEVIE-name of the table: `PSL2.3`
+
 
 - The table was first (implicitly) computed in [Fro96](@cite).
 

--- a/data/Tables/A1/SL2.0.jl
+++ b/data/Tables/A1/SL2.0.jl
@@ -87,8 +87,6 @@ charparamindex = var_index.([n])
 information = raw"""The generic character table of $\mathrm{SL}_2(q)$, $q$ even
   (See `SL2.1` for the generic character table of $\mathrm{SL}_2(q)$, $q$ odd)
 
-
-
 - The table was first computed in [Sch07](@cite).
 """
 

--- a/data/Tables/A1/SL2.0.jl
+++ b/data/Tables/A1/SL2.0.jl
@@ -84,7 +84,7 @@ charparams = [
 classparamindex = var_index.([a])
 charparamindex = var_index.([n])
 
-information = raw"""- Information about the generic character table of $\mathrm{SL}_2(q)$, $q$ even
+information = raw"""The generic character table of $\mathrm{SL}_2(q)$, $q$ even
   (See `SL2.1` for the generic character table of $\mathrm{SL}_2(q)$, $q$ odd)
 
 - CHEVIE-name of the table: `SL2.0`

--- a/data/Tables/A1/SL2.0.jl
+++ b/data/Tables/A1/SL2.0.jl
@@ -87,7 +87,7 @@ charparamindex = var_index.([n])
 information = raw"""The generic character table of $\mathrm{SL}_2(q)$, $q$ even
   (See `SL2.1` for the generic character table of $\mathrm{SL}_2(q)$, $q$ odd)
 
-- CHEVIE-name of the table: `SL2.0`
+
 
 - The table was first computed in [Sch07](@cite).
 """

--- a/data/Tables/A1/SL2.1.jl
+++ b/data/Tables/A1/SL2.1.jl
@@ -165,7 +165,7 @@ charparamindex = var_index.([k])
 
 information = raw"""- Information about the generic character table of $\mathrm{SL}_2(q)$,
   $q$ odd. The possible values for $q$ are given by
-  $q = q0^2 = p^m$ with m a non negative integer and $p$ a prime number.
+  $q = q_0^2 = p^m$ with m a non negative integer and $p$ a prime number.
   Note that the variable $q_0$ represents $\sqrt{q}$ which is needed as
   some table entries involve this value.
   (See `SL2.0` for the generic character table of $\mathrm{SL}_2(q)$, $q$ even).

--- a/data/Tables/A1/SL2.1.jl
+++ b/data/Tables/A1/SL2.1.jl
@@ -163,7 +163,7 @@ charparams = [
 classparamindex = var_index.([i])
 charparamindex = var_index.([k])
 
-information = raw"""- Information about the generic character table of $\mathrm{SL}_2(q)$,
+information = raw"""The generic character table of $\mathrm{SL}_2(q)$,
   $q$ odd. The possible values for $q$ are given by
   $q = q_0^2 = p^m$ with m a non negative integer and $p$ a prime number.
   Note that the variable $q_0$ represents $\sqrt{q}$ which is needed as

--- a/data/Tables/A1/SL2.1.jl
+++ b/data/Tables/A1/SL2.1.jl
@@ -170,7 +170,7 @@ information = raw"""The generic character table of $\mathrm{SL}_2(q)$,
   some table entries involve this value.
   (See `SL2.0` for the generic character table of $\mathrm{SL}_2(q)$, $q$ even).
 
-- CHEVIE-name of the table: `SL2.1`
+
 
 - The table was first computed in [Fro96](@cite).
 

--- a/data/Tables/A1/SL2.1.jl
+++ b/data/Tables/A1/SL2.1.jl
@@ -170,8 +170,6 @@ information = raw"""The generic character table of $\mathrm{SL}_2(q)$,
   some table entries involve this value.
   (See `SL2.0` for the generic character table of $\mathrm{SL}_2(q)$, $q$ even).
 
-
-
 - The table was first computed in [Fro96](@cite).
 
 - See also: [Sch07](@cite).

--- a/data/Tables/A2/GL3.jl
+++ b/data/Tables/A2/GL3.jl
@@ -320,7 +320,7 @@ charparams = [
 classparamindex = var_index.([a, b, c])
 charparamindex = var_index.([l, m, n])
 
-information = raw"""- Information about the generic character table of $\mathrm{GL}_3(q)$.
+information = raw"""The generic character table of $\mathrm{GL}_3(q)$.
 
 - CHEVIE-name of the table: `GL3`
 

--- a/data/Tables/A2/GL3.jl
+++ b/data/Tables/A2/GL3.jl
@@ -322,7 +322,7 @@ charparamindex = var_index.([l, m, n])
 
 information = raw"""The generic character table of $\mathrm{GL}_3(q)$.
 
-- CHEVIE-name of the table: `GL3`
+
 
 - The table was first computed in [Ste51](@cite).
 

--- a/data/Tables/A2/GL3.jl
+++ b/data/Tables/A2/GL3.jl
@@ -322,8 +322,6 @@ charparamindex = var_index.([l, m, n])
 
 information = raw"""The generic character table of $\mathrm{GL}_3(q)$.
 
-
-
 - The table was first computed in [Ste51](@cite).
 
 - See also: [Gre55](@cite).

--- a/data/Tables/A2/PGL3.1.jl
+++ b/data/Tables/A2/PGL3.1.jl
@@ -302,8 +302,6 @@ information = raw"""The generic character table of $\mathrm{PGL}_3(q)$,
   (See `SL3.n1` for the generic character table of $\mathrm{PGL}_3(q)$,
   $q$ not congruent to $1$ modulo $3$.)
 
-
-
 - The table was first computed in [Ste51](@cite).
 
 - See also: [Gre55](@cite).

--- a/data/Tables/A2/PGL3.1.jl
+++ b/data/Tables/A2/PGL3.1.jl
@@ -297,7 +297,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([m, n])
 
-information = raw"""- Information about the generic character table of $\mathrm{PGL}_3(q)$,
+information = raw"""The generic character table of $\mathrm{PGL}_3(q)$,
   $q$ congruent to $1$ modulo $3$.
   (See `SL3.n1` for the generic character table of $\mathrm{PGL}_3(q)$,
   $q$ not congruent to $1$ modulo $3$.)

--- a/data/Tables/A2/PGL3.1.jl
+++ b/data/Tables/A2/PGL3.1.jl
@@ -302,7 +302,7 @@ information = raw"""The generic character table of $\mathrm{PGL}_3(q)$,
   (See `SL3.n1` for the generic character table of $\mathrm{PGL}_3(q)$,
   $q$ not congruent to $1$ modulo $3$.)
 
-- CHEVIE-name of the table: `PGL3.1`
+
 
 - The table was first computed in [Ste51](@cite).
 

--- a/data/Tables/A2/PSL3.1.jl
+++ b/data/Tables/A2/PSL3.1.jl
@@ -366,7 +366,7 @@ information = raw"""The generic character table of $\mathrm{PSL}_3(q)$,
   (See `SL3.n1` for the generic character table of $\mathrm{PSL}_3(q)$,
   $q$ not congruent to $1$ modulo $3$.)
 
-- CHEVIE-name of the table: `PSL3.1`
+
 
 - The table was first computed in [SF73](@cite).
 

--- a/data/Tables/A2/PSL3.1.jl
+++ b/data/Tables/A2/PSL3.1.jl
@@ -366,8 +366,6 @@ information = raw"""The generic character table of $\mathrm{PSL}_3(q)$,
   (See `SL3.n1` for the generic character table of $\mathrm{PSL}_3(q)$,
   $q$ not congruent to $1$ modulo $3$.)
 
-
-
 - The table was first computed in [SF73](@cite).
 
 - The table was constructed by Jochen Gruber from the generic character

--- a/data/Tables/A2/PSL3.1.jl
+++ b/data/Tables/A2/PSL3.1.jl
@@ -361,7 +361,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([m, n])
 
-information = raw"""- Information about the generic character table of $\mathrm{PSL}_3(q)$,
+information = raw"""The generic character table of $\mathrm{PSL}_3(q)$,
   $q$ congruent to $1$ modulo $3$.
   (See `SL3.n1` for the generic character table of $\mathrm{PSL}_3(q)$,
   $q$ not congruent to $1$ modulo $3$.)

--- a/data/Tables/A2/SL3.1.jl
+++ b/data/Tables/A2/SL3.1.jl
@@ -428,7 +428,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([m, n])
 
-information = raw"""- Information about the generic character table of $\mathrm{SL}_3(q)$,
+information = raw"""The generic character table of $\mathrm{SL}_3(q)$,
   $q$ congruent to $1$ modulo $3$.
   (See `SL3.n1` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ not congruent to $1$ modulo $3$.)

--- a/data/Tables/A2/SL3.1.jl
+++ b/data/Tables/A2/SL3.1.jl
@@ -433,8 +433,6 @@ information = raw"""The generic character table of $\mathrm{SL}_3(q)$,
   (See `SL3.n1` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ not congruent to $1$ modulo $3$.)
 
-
-
 - The table was first computed in [SF73](@cite).
 
 - See also: [Ste51](@cite), [Gre55](@cite).

--- a/data/Tables/A2/SL3.1.jl
+++ b/data/Tables/A2/SL3.1.jl
@@ -433,7 +433,7 @@ information = raw"""The generic character table of $\mathrm{SL}_3(q)$,
   (See `SL3.n1` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ not congruent to $1$ modulo $3$.)
 
-- CHEVIE-name of the table: `SL3.1`
+
 
 - The table was first computed in [SF73](@cite).
 

--- a/data/Tables/A2/SL3.n1.jl
+++ b/data/Tables/A2/SL3.n1.jl
@@ -261,7 +261,7 @@ information = raw"""The generic character table of $\mathrm{SL}_3(q)$,
   The three groups $\mathrm{SL}_3(q)$, $\mathrm{PGL}_3(q)$ and $\mathrm{PSL}_3(q)$ are
   mutually isomorphic for these values of $q$.
 
-- CHEVIE-name of the table: `SL3.n1`
+
 
 - The table was first computed in [SF73](@cite).
 

--- a/data/Tables/A2/SL3.n1.jl
+++ b/data/Tables/A2/SL3.n1.jl
@@ -261,8 +261,6 @@ information = raw"""The generic character table of $\mathrm{SL}_3(q)$,
   The three groups $\mathrm{SL}_3(q)$, $\mathrm{PGL}_3(q)$ and $\mathrm{PSL}_3(q)$ are
   mutually isomorphic for these values of $q$.
 
-
-
 - The table was first computed in [SF73](@cite).
 
 - See also: [Ste51](@cite), [Gre55](@cite).

--- a/data/Tables/A2/SL3.n1.jl
+++ b/data/Tables/A2/SL3.n1.jl
@@ -252,7 +252,7 @@ charparams = [
 classparamindex = var_index.([a, b])
 charparamindex = var_index.([m, n])
 
-information = raw"""- Information about the generic character table of $\mathrm{SL}_3(q)$,
+information = raw"""The generic character table of $\mathrm{SL}_3(q)$,
   $q$ not congruent to $1$ modulo $3$
   (See `SL3.1` for the generic character table of $\mathrm{SL}_3(q)$,
   $q$ congruent to $1$ modulo $3$.)

--- a/data/Tables/C2/Sp4.0.jl
+++ b/data/Tables/C2/Sp4.0.jl
@@ -779,7 +779,7 @@ charparamindex = var_index.([k, l])
 
 information = raw"""The generic character table of $\mathrm{Sp}_4(q)$, $q$ even
 
-- CHEVIE-name of the table: `Sp4.0`
+
 
 - The table was first computed in [Eno72](@cite)
 

--- a/data/Tables/C2/Sp4.0.jl
+++ b/data/Tables/C2/Sp4.0.jl
@@ -784,7 +784,7 @@ information = raw"""- Information about the generic character table of $\mathrm{
 - The table was first computed in [Eno72](@cite)
 
 - The table in the cited paper contains a lot of misprints.
-  The table in the CHEVIE-library was recomputed by F.Luebeck
+  The table in the CHEVIE-library was recomputed by F. Lübeck
   (using Deligne-Lusztig theory).
 
 - The names for the class (respectively character) types used in the

--- a/data/Tables/C2/Sp4.0.jl
+++ b/data/Tables/C2/Sp4.0.jl
@@ -785,16 +785,20 @@ information = raw"""- Information about the generic character table of $\mathrm{
 
 - The table in the cited paper contains a lot of misprints.
   The table in the CHEVIE-library was recomputed by F.Luebeck
-  (using Deligne--Lusztig theory).
+  (using Deligne-Lusztig theory).
 
 - The names for the class (respectively character) types used in the
-  paper of Enomoto can be found as 4th component of the lists
-  in the (-1)st row (resp. column) of the table. Example:
-> ``Sp4.0``[-1,3][4];
+  paper of Enomoto can be found as 3rd component of the list returned
+  by the `info` functions when applied to the class type. Example:
+  ```jldoctest
+  julia> t = generic_character_table("Sp4.0");
+  
+  julia> cls = t[:,3];  # get the third column
 
-                                      A31
-
-  shows, that the class type of the third column of the table
+  julia> info(cls)[3]
+  "A31"
+  ```
+  This shows that the class type of the third column of the table
   is called A31 by Enomoto.
 """
 

--- a/data/Tables/C2/Sp4.0.jl
+++ b/data/Tables/C2/Sp4.0.jl
@@ -779,8 +779,6 @@ charparamindex = var_index.([k, l])
 
 information = raw"""The generic character table of $\mathrm{Sp}_4(q)$, $q$ even
 
-
-
 - The table was first computed in [Eno72](@cite)
 
 - The table in the cited paper contains a lot of misprints.

--- a/data/Tables/C2/Sp4.0.jl
+++ b/data/Tables/C2/Sp4.0.jl
@@ -777,7 +777,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $\mathrm{Sp}_4(q)$, $q$ even
+information = raw"""The generic character table of $\mathrm{Sp}_4(q)$, $q$ even
 
 - CHEVIE-name of the table: `Sp4.0`
 

--- a/data/Tables/C2/uniCSp4.1.jl
+++ b/data/Tables/C2/uniCSp4.1.jl
@@ -255,7 +255,7 @@ chardegree =
     q^4,
   ])
 
-information = raw"""- Information about the generic character table of $\mathrm{CSp}_4(q)$ with odd $q$
+information = raw"""The generic character table of $\mathrm{CSp}_4(q)$ with odd $q$
   (unipotent characters).
 
 - CHEVIE-name of the table: `uniCSp4.1`

--- a/data/Tables/C2/uniCSp4.1.jl
+++ b/data/Tables/C2/uniCSp4.1.jl
@@ -258,8 +258,6 @@ chardegree =
 information = raw"""The generic character table of $\mathrm{CSp}_4(q)$ with odd $q$
   (unipotent characters).
 
-
-
 - The table was first computed in [Shi82](@cite).
 
 - The name of the i-th class type in the cited paper can be found by:

--- a/data/Tables/C2/uniCSp4.1.jl
+++ b/data/Tables/C2/uniCSp4.1.jl
@@ -258,7 +258,7 @@ chardegree =
 information = raw"""The generic character table of $\mathrm{CSp}_4(q)$ with odd $q$
   (unipotent characters).
 
-- CHEVIE-name of the table: `uniCSp4.1`
+
 
 - The table was first computed in [Shi82](@cite).
 

--- a/data/Tables/C2/uniCSp4.1.jl
+++ b/data/Tables/C2/uniCSp4.1.jl
@@ -260,9 +260,9 @@ information = raw"""The generic character table of $\mathrm{CSp}_4(q)$ with odd 
 
 - The table was first computed in [Shi82](@cite).
 
-- The name of the i-th class type in the cited paper can be found by:
-  > ``uniCSp4.1``[-1,i][4];
-  or with 'PrintInfoClass'.
+- The name of the i-th class type in the cited paper can be found as
+  3rd component of the list returned by the `info` function when
+  applied to the i-th class type.
 
 - This release of CHEVIE only contains the unipotent characters.
   We have a preliminary version of the complete table, but it contains

--- a/data/Tables/C3/CSp6.1.jl
+++ b/data/Tables/C3/CSp6.1.jl
@@ -11394,18 +11394,8 @@ information = raw"""The generic character table of $\mathrm{CSp}_6(q)$, $q$ odd
 
 - The computation of this table is explained in [Lbe93](@cite).
 
-- This table is very big. The best way to work with it
-  is to produce one time a file in ``Maple-internal-format``
-  (in a new cheviem-session say:
-> GenCharTab(``CSp6.1``);save ``CSp6_1.m``;quit;
-  and ask your system-administrator to copy  the file
-  CSp6_1.m into the CHEVIE-directory tables/C3/CSp6_1.m).
-  Now you can read in this table with the CHEVIE-command
-> GenCharTab(``CSp6_1.m``);
-  This is much faster and uses much less memory.
-
 - The first twelve character types contain the unipotent characters.
-  Specialize  the parameter kK1 to a multiple of q-1 e.g., kK1=0.
+  Specialize  the parameter `k1` to a multiple of $q-1$ e.g., `k1=0`.
   If you are *only* interested in the unipotent characters, you can
   use the table `uniCSp6.1`, which allows faster calculations.
 """

--- a/data/Tables/C3/CSp6.1.jl
+++ b/data/Tables/C3/CSp6.1.jl
@@ -11392,7 +11392,7 @@ charparamindex = var_index.([k1, k2, k3, k4])
 
 information = raw"""The generic character table of $\mathrm{CSp}_6(q)$, $q$ odd
 
-- CHEVIE-name of the table: `CSp6.1`
+
 
 - The computation of this table is explained in [Lbe93](@cite).
 

--- a/data/Tables/C3/CSp6.1.jl
+++ b/data/Tables/C3/CSp6.1.jl
@@ -11390,7 +11390,7 @@ charparams = [
 classparamindex = var_index.([i1, i2, i3, i4])
 charparamindex = var_index.([k1, k2, k3, k4])
 
-information = raw"""- Information about the generic character table of $\mathrm{CSp}_6(q)$, $q$ odd
+information = raw"""The generic character table of $\mathrm{CSp}_6(q)$, $q$ odd
 
 - CHEVIE-name of the table: `CSp6.1`
 

--- a/data/Tables/C3/CSp6.1.jl
+++ b/data/Tables/C3/CSp6.1.jl
@@ -11392,8 +11392,6 @@ charparamindex = var_index.([k1, k2, k3, k4])
 
 information = raw"""The generic character table of $\mathrm{CSp}_6(q)$, $q$ odd
 
-
-
 - The computation of this table is explained in [Lbe93](@cite).
 
 - This table is very big. The best way to work with it

--- a/data/Tables/C3/Sp6.0.jl
+++ b/data/Tables/C3/Sp6.0.jl
@@ -11353,7 +11353,7 @@ charparamindex = var_index.([k1, k2, k3])
 
 information = raw"""The generic character table of $\mathrm{Sp}_6(q)$, $q$ even
 
-- CHEVIE-name of the table: `Sp6.0`
+
 
 - The computation of this table is explained in [Lbe93](@cite).
 

--- a/data/Tables/C3/Sp6.0.jl
+++ b/data/Tables/C3/Sp6.0.jl
@@ -11358,17 +11358,7 @@ information = raw"""The generic character table of $\mathrm{Sp}_6(q)$, $q$ even
 - The irreducible characters of $\mathrm{Sp}_6(q)$ with even $q$ were already
   (independently) determined in [Loo77](@cite).
 
-- This table is very big. The best way to work with it
-  is to produce one time a file in ``Maple-internal-format``
-  (in a new cheviem-session say:
-> GenCharTab(``Sp6.0``);save ``Sp6_0.m``;quit;
-  and ask your system-administrator to copy  the file
-  Sp6_0.m into the CHEVIE-directory tables/C3/Sp6_0.m).
-  Now you can read in this table with the CHEVIE-command
-> GenCharTab(``Sp6_0.m``);
-  This is much faster and uses much less memory.
-
-- The first twelve character(type)s are the unipotent characters.
+- The first twelve character types are the unipotent characters.
   If you are *only* interested in the unipotent characters, you can
   use the table `uniSp6.0`, which allows faster calculations.
 """

--- a/data/Tables/C3/Sp6.0.jl
+++ b/data/Tables/C3/Sp6.0.jl
@@ -11353,8 +11353,6 @@ charparamindex = var_index.([k1, k2, k3])
 
 information = raw"""The generic character table of $\mathrm{Sp}_6(q)$, $q$ even
 
-
-
 - The computation of this table is explained in [Lbe93](@cite).
 
 - The irreducible characters of $\mathrm{Sp}_6(q)$ with even $q$ were already

--- a/data/Tables/C3/Sp6.0.jl
+++ b/data/Tables/C3/Sp6.0.jl
@@ -11351,7 +11351,7 @@ charparams = [
 classparamindex = var_index.([i1, i2, i3])
 charparamindex = var_index.([k1, k2, k3])
 
-information = raw"""- Information about the generic character table of $\mathrm{Sp}_6(q)$, $q$ even
+information = raw"""The generic character table of $\mathrm{Sp}_6(q)$, $q$ even
 
 - CHEVIE-name of the table: `Sp6.0`
 

--- a/data/Tables/C3/uniCSp6.1.jl
+++ b/data/Tables/C3/uniCSp6.1.jl
@@ -1394,14 +1394,13 @@ information = raw"""The unipotent characters of $\mathrm{CSp}_6(q)$, $q$ odd
 
 - This table is extracted from the table `CSp6.1`, which
   contains the unipotent characters in the first 12 character
-  types (specialize the parameter kK1 to 0).
+  types (specialize the parameter `k1` to $0$).
 
 - If you want to calculate *only* with the unipotent characters
   then use this table `uniCSp6.1` (the calculations will run
   much faster). If you also want to use the other characters
   of `CSp6.1`, then produce the unipotent characters with the
-  CHEVIE-commands ``Copy`` and ``SpecCharParam`` as explained
-  above.
+  `specialize` function as explained above.
 """
 
 SimpleCharTable(

--- a/data/Tables/C3/uniCSp6.1.jl
+++ b/data/Tables/C3/uniCSp6.1.jl
@@ -1390,7 +1390,7 @@ chardegree =
 
 information = raw"""The unipotent characters of $\mathrm{CSp}_6(q)$, $q$ odd
 
-- CHEVIE-name of the table: `uniCSp6.1`
+
 
 - The computation of the whole table of this group is explained in [Lbe93](@cite).
 

--- a/data/Tables/C3/uniCSp6.1.jl
+++ b/data/Tables/C3/uniCSp6.1.jl
@@ -1388,7 +1388,7 @@ chardegree =
     1//2 * (q - 1)^2 * q^4 * (q^2 + q + 1),
     q^9])
 
-information = raw"""- Information about the table of unipotent characters of $\mathrm{CSp}_6(q)$, $q$ odd
+information = raw"""The unipotent characters of $\mathrm{CSp}_6(q)$, $q$ odd
 
 - CHEVIE-name of the table: `uniCSp6.1`
 

--- a/data/Tables/C3/uniCSp6.1.jl
+++ b/data/Tables/C3/uniCSp6.1.jl
@@ -1390,8 +1390,6 @@ chardegree =
 
 information = raw"""The unipotent characters of $\mathrm{CSp}_6(q)$, $q$ odd
 
-
-
 - The computation of the whole table of this group is explained in [Lbe93](@cite).
 
 - This table is extracted from the table `CSp6.1`, which

--- a/data/Tables/C3/uniSp6.0.jl
+++ b/data/Tables/C3/uniSp6.0.jl
@@ -1037,12 +1037,12 @@ information = raw"""The unipotent characters of $\mathrm{Sp}_6(q)$, $q$ even
 
 - This table is extracted from the table `Sp6.0`, which
   contains the unipotent characters in the first 12 character
-  (type)s.
+  types.
 
 - If you want to calculate *only* with the unipotent characters
   then use this table `uniSp6.0` (the calculations will run
   much faster). If you also want to use the other characters
-  of `Sp6.0`, then dont use `uniSp6.0`.
+  of `Sp6.0`, then don't use `uniSp6.0`.
 """
 
 SimpleCharTable(

--- a/data/Tables/C3/uniSp6.0.jl
+++ b/data/Tables/C3/uniSp6.0.jl
@@ -1030,7 +1030,7 @@ chardegree =
 
 information = raw"""The unipotent characters of $\mathrm{Sp}_6(q)$, $q$ even
 
-- CHEVIE-name of the table: `uniSp6.0`
+
 
 - The computation of the whole table of this group is explained in [Lbe93](@cite).
 

--- a/data/Tables/C3/uniSp6.0.jl
+++ b/data/Tables/C3/uniSp6.0.jl
@@ -1030,8 +1030,6 @@ chardegree =
 
 information = raw"""The unipotent characters of $\mathrm{Sp}_6(q)$, $q$ even
 
-
-
 - The computation of the whole table of this group is explained in [Lbe93](@cite).
 
 - The irreducible characters of $\mathrm{Sp}_6(q)$ with even $q$ were already

--- a/data/Tables/C3/uniSp6.0.jl
+++ b/data/Tables/C3/uniSp6.0.jl
@@ -1028,7 +1028,7 @@ chardegree =
     1//2 * q^4 * (q^2 + q + 1) * (q - 1)^2,
     q^9])
 
-information = raw"""- Information about the table of unipotent characters of $\mathrm{Sp}_6(q)$, $q$ even
+information = raw"""The unipotent characters of $\mathrm{Sp}_6(q)$, $q$ even
 
 - CHEVIE-name of the table: `uniSp6.0`
 

--- a/data/Tables/D4/uniCSpin8.1.jl
+++ b/data/Tables/D4/uniCSpin8.1.jl
@@ -3002,8 +3002,6 @@ chardegree =
 
 information = raw"""The unipotent characters of $\mathrm{CSpin}_8(q)$, $q$ odd
 
-
-
 - The table was first computed in [GP92](@cite).
 
 - The symbols parametrizing the unipotent characters are given in form

--- a/data/Tables/D4/uniCSpin8.1.jl
+++ b/data/Tables/D4/uniCSpin8.1.jl
@@ -3005,8 +3005,8 @@ information = raw"""The unipotent characters of $\mathrm{CSpin}_8(q)$, $q$ odd
 - The table was first computed in [GP92](@cite).
 
 - The symbols parametrizing the unipotent characters are given in form
-  of a pair of lists in (the 2nd part of) position 3 of the character
-  information list. (Look at ``uniCSpin8.1``[i,-1][3][2], i = 1, ... ,14.)
+  of a pair of lists in (the 2nd part of) position 2 of the character
+  information list returned by the `info` function.
 """
 
 SimpleCharTable(

--- a/data/Tables/D4/uniCSpin8.1.jl
+++ b/data/Tables/D4/uniCSpin8.1.jl
@@ -3000,7 +3000,7 @@ chardegree =
     q^7 * (q^2 + 1)^2,
     q^12])
 
-information = raw"""- Information about the unipotent character table of $\mathrm{CSpin}_8(q)$, $q$ odd
+information = raw"""The unipotent characters of $\mathrm{CSpin}_8(q)$, $q$ odd
 
 - CHEVIE-name of the table: `uniCSpin8.1`
 

--- a/data/Tables/D4/uniCSpin8.1.jl
+++ b/data/Tables/D4/uniCSpin8.1.jl
@@ -3002,7 +3002,7 @@ chardegree =
 
 information = raw"""The unipotent characters of $\mathrm{CSpin}_8(q)$, $q$ odd
 
-- CHEVIE-name of the table: `uniCSpin8.1`
+
 
 - The table was first computed in [GP92](@cite).
 

--- a/data/Tables/D4/uniSpin8.0.jl
+++ b/data/Tables/D4/uniSpin8.0.jl
@@ -2475,7 +2475,7 @@ chardegree =
 
 information = raw"""The unipotent characters of $\mathrm{Spin}_8(q)$, $q$ even
 
-- CHEVIE-name of the table: `uniSpin8.0`
+
 
 - The table was first computed by Meinolf Geck (unpublished).
 

--- a/data/Tables/D4/uniSpin8.0.jl
+++ b/data/Tables/D4/uniSpin8.0.jl
@@ -2475,8 +2475,6 @@ chardegree =
 
 information = raw"""The unipotent characters of $\mathrm{Spin}_8(q)$, $q$ even
 
-
-
 - The table was first computed by Meinolf Geck (unpublished).
 
 - The symbols parametrizing the unipotent characters are given in form

--- a/data/Tables/D4/uniSpin8.0.jl
+++ b/data/Tables/D4/uniSpin8.0.jl
@@ -2473,7 +2473,7 @@ chardegree =
     q^7 * (q^2 + 1)^2,
     q^12])
 
-information = raw"""- Information about the unipotent character table of $\mathrm{Spin}_8(q)$, $q$ even
+information = raw"""The unipotent characters of $\mathrm{Spin}_8(q)$, $q$ even
 
 - CHEVIE-name of the table: `uniSpin8.0`
 

--- a/data/Tables/D4/uniSpin8.0.jl
+++ b/data/Tables/D4/uniSpin8.0.jl
@@ -2478,8 +2478,8 @@ information = raw"""The unipotent characters of $\mathrm{Spin}_8(q)$, $q$ even
 - The table was first computed by Meinolf Geck (unpublished).
 
 - The symbols parametrizing the unipotent characters are given in form
-  of a pair of lists in (the 2nd part of) position 3 of the character
-  information list. (Look at ``uniSpin8.0``[i,-1][3][2], i = 1, ... ,14.)
+  of a pair of lists in (the 2nd part of) position 2 of the character
+  information list returned by the `info` function.
 """
 
 SimpleCharTable(

--- a/data/Tables/F4/uniuniF4p2.jl
+++ b/data/Tables/F4/uniuniF4p2.jl
@@ -1653,7 +1653,7 @@ charparams = [
 classparamindex = Int64[]
 charparamindex = Int64[]
 
-information = raw"""- Information about the table of unipotent characters of $\mathrm{F}_4(2^n)$
+information = raw"""The unipotent characters of $\mathrm{F}_4(2^n)$
   on unipotent classes.
 
 - CHEVIE-name of the table: `uniuniF4p2`

--- a/data/Tables/F4/uniuniF4p2.jl
+++ b/data/Tables/F4/uniuniF4p2.jl
@@ -1656,8 +1656,6 @@ charparamindex = Int64[]
 information = raw"""The unipotent characters of $\mathrm{F}_4(2^n)$
   on unipotent classes.
 
-
-
 - The table was computed by Marcelo and Shinoda. This is explained in [MS95](@cite).
 
 - PrintInfoClass shows the geometric unipotent classes in the notation of

--- a/data/Tables/F4/uniuniF4p2.jl
+++ b/data/Tables/F4/uniuniF4p2.jl
@@ -1656,7 +1656,7 @@ charparamindex = Int64[]
 information = raw"""The unipotent characters of $\mathrm{F}_4(2^n)$
   on unipotent classes.
 
-- CHEVIE-name of the table: `uniuniF4p2`
+
 
 - The table was computed by Marcelo and Shinoda. This is explained in [MS95](@cite).
 

--- a/data/Tables/G2/G2.01.jl
+++ b/data/Tables/G2/G2.01.jl
@@ -1451,7 +1451,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $\mathrm{G}_2(q)$,
+information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ even, congruent to $1$ modulo $3$
 
 - CHEVIE-name of the table: `G2.01`

--- a/data/Tables/G2/G2.01.jl
+++ b/data/Tables/G2/G2.01.jl
@@ -1454,8 +1454,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ even, congruent to $1$ modulo $3$
 
-
-
 - The table was first computed in [EY86](@cite).
 
 - See also: [CR74](@cite), [Hi90](@cite).

--- a/data/Tables/G2/G2.01.jl
+++ b/data/Tables/G2/G2.01.jl
@@ -1454,7 +1454,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ even, congruent to $1$ modulo $3$
 
-- CHEVIE-name of the table: `G2.01`
+
 
 - The table was first computed in [EY86](@cite).
 

--- a/data/Tables/G2/G2.01.jl
+++ b/data/Tables/G2/G2.01.jl
@@ -1460,26 +1460,30 @@ information = raw"""The generic character table of $\mathrm{G}_2(q)$,
 
 - Note:
   Enomoto's and Yamada's notation for the irreducible characters is
-  given in the fifth component of the character information list.
+  given in the fourth component of the character information list.
 
   An equivalent to Chang's and Ree's notation for the irreducible
-  characters is given in the fourth component of the character
+  characters is given in the third component of the character
   information list.
 
   Enomoto's and Yamada's notation for the conjugacy classes is given in
-  the fourth component of the class information list.
+  the third component of the class information list.
 
 - Example:
-> PrintInfoChar(``G2.01``,6);
+  ```jldoctest
+  julia> t = generic_character_table("G2.01");
 
-cht   Information
-
-======================================================
-6   [ , [1, 5], [G_2, G_2[1]], X_{18}, \vartheta_1']
+  julia> info(t[6])
+  4-element Vector{Any}:
+   [1, 5]
+   ["G_2", "G_2[1]"]
+   "X_{18}"
+   "\\vartheta_1'"
+  ```
 
 - Explanation of example:
-  Character type 6 of G2.01 is called \vartheta_1' by Enomoto--Yamada
-  and corresponds to X_{18} in Chang--Ree.
+  Character type six of `G2.01` is called $\vartheta_1$ by Enomoto--Yamada
+  and corresponds to $X_{18}$ in Chang--Ree.
 """
 
 CharTable(order, permutedims(table), classinfo, classlength, charinfo, chardegree,

--- a/data/Tables/G2/G2.02.jl
+++ b/data/Tables/G2/G2.02.jl
@@ -1451,7 +1451,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $\mathrm{G}_2(q)$,
+information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ even, congruent to $2$ modulo $3$
 
 - CHEVIE-name of the table: `G2.02`

--- a/data/Tables/G2/G2.02.jl
+++ b/data/Tables/G2/G2.02.jl
@@ -1454,8 +1454,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ even, congruent to $2$ modulo $3$
 
-
-
 - The table was first computed in [EY86](@cite).
 
 - See also: [CR74](@cite), [Hi90](@cite).

--- a/data/Tables/G2/G2.02.jl
+++ b/data/Tables/G2/G2.02.jl
@@ -1454,7 +1454,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ even, congruent to $2$ modulo $3$
 
-- CHEVIE-name of the table: `G2.02`
+
 
 - The table was first computed in [EY86](@cite).
 

--- a/data/Tables/G2/G2.02.jl
+++ b/data/Tables/G2/G2.02.jl
@@ -1460,26 +1460,30 @@ information = raw"""The generic character table of $\mathrm{G}_2(q)$,
 
 - Note:
   Enomoto's and Yamada's notation for the irreducible characters is
-  given in the fifth component of the character information list.
+  given in the fourth component of the character information list.
 
   An equivalent to Chang's and Ree's notation for the irreducible
-  characters is given in the fourth component of the character
+  characters is given in the third component of the character
   information list.
 
   Enomoto's and Yamada's notation for the conjugacy classes is given in
-  the fourth component of the class information list.
+  the third component of the class information list.
 
 - Example:
-> PrintInfoChar(``G2.02``,6);
+  ```jldoctest
+  julia> t = generic_character_table("G2.02");
 
-cht   Information
-
-======================================================
-6   [ , [1, 5], [G_2, G_2[1]], X_{18}, \vartheta_1']
+  julia> info(t[6])
+  4-element Vector{Any}:
+   [1, 5]
+   ["G_2", "G_2[1]"]
+   "X_{18}"
+   "\\vartheta_1'"
+  ```
 
 - Explanation of example:
-  Character type 6 of G2.02 is called \vartheta_1' by Enomoto--Yamada
-  and corresponds to X_{18} in Chang--Ree.
+  Character type six of `G2.02` is called $\vartheta_1$ by Enomoto--Yamada
+  and corresponds to $X_{18}$ in Chang--Ree.
 """
 
 CharTable(order, permutedims(table), classinfo, classlength, charinfo, chardegree,

--- a/data/Tables/G2/G2.101.jl
+++ b/data/Tables/G2/G2.101.jl
@@ -1568,8 +1568,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ a power of $3$, congruent to $1$ modulo $4$.
 
-
-
 - The table was first computed in [Eno76](@cite).
 
 - See also: [CR74](@cite), [Hi90](@cite).

--- a/data/Tables/G2/G2.101.jl
+++ b/data/Tables/G2/G2.101.jl
@@ -1574,26 +1574,30 @@ information = raw"""The generic character table of $\mathrm{G}_2(q)$,
 
 - Note:
   Enomoto's notation for the irreducible characters is given in
-  the fifth component of the character information list.
+  the fourth component of the character information list.
 
   An equivalent to Chang's and Ree's notation for the irreducible
-  characters is given in the fourth component of the character
+  characters is given in the third component of the character
   information list.
 
   Enomoto's notation for the conjugacy classes is given in the
-  fourth component of the class information list.
+  third component of the class information list.
 
 - Example:
-> PrintInfoChar(``G2.10``,6);
+  ```jldoctest
+  julia> t = generic_character_table("G2.101");
 
-cht   Information
-
-======================================================
-6   [ , [1, 5], [G_2, G_2[1]], X_{18}, \vartheta_{10}]
+  julia> info(t[6])
+  4-element Vector{Any}:
+   [1, 5]
+   ["G_2", "G_2[1]"]
+   "X_{18}"
+   "\\vartheta_{10}"
+  ```
 
 - Explanation of example:
-  Character type 6 of G2.10 is called \vartheta_{10} by Enomoto
-  and corresponds to X_{18} in Chang--Ree.
+  Character type six of `G2.101` is called $\vartheta_{10}$ by Enomoto
+  and corresponds to $X_{18}$ in Chang--Ree.
 """
 
 CharTable(order, permutedims(table), classinfo, classlength, charinfo, chardegree,

--- a/data/Tables/G2/G2.101.jl
+++ b/data/Tables/G2/G2.101.jl
@@ -1565,7 +1565,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $\mathrm{G}_2(q)$,
+information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ a power of $3$, congruent to $1$ modulo $4$.
 
 - CHEVIE-name of the table: `G2.10`

--- a/data/Tables/G2/G2.101.jl
+++ b/data/Tables/G2/G2.101.jl
@@ -1568,7 +1568,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ a power of $3$, congruent to $1$ modulo $4$.
 
-- CHEVIE-name of the table: `G2.10`
+
 
 - The table was first computed in [Eno76](@cite).
 

--- a/data/Tables/G2/G2.103.jl
+++ b/data/Tables/G2/G2.103.jl
@@ -1574,26 +1574,30 @@ information = raw"""The generic character table of $\mathrm{G}_2(q)$,
 
 - Note:
   Enomoto's notation for the irreducible characters is given in
-  the fifth component of the character information list.
+  the fourth component of the character information list.
 
   An equivalent to Chang's and Ree's notation for the irreducible
-  characters is given in the fourth component of the character
+  characters is given in the third component of the character
   information list.
 
   Enomoto's notation for the conjugacy classes is given in the
-  fourth component of the class information list.
+  third component of the class information list.
 
 - Example:
-> PrintInfoChar(``G2.10``,6);
+  ```jldoctest
+  julia> t = generic_character_table("G2.103");
 
-cht   Information
-
-======================================================
-6   [ , [1, 5], [G_2, G_2[1]], X_{18}, \vartheta_{10}]
+  julia> info(t[6])
+  4-element Vector{Any}:
+   [1, 5]
+   ["G_2", "G_2[1]"]
+   "X_{18}"
+   "\\vartheta_{10}"
+  ```
 
 - Explanation of example:
-  Character type 6 of G2.10 is called \vartheta_{10} by Enomoto
-  and corresponds to X_{18} in Chang--Ree.
+  Character type six of `G2.103` is called $\vartheta_{10}$ by Enomoto
+  and corresponds to $X_{18}$ in Chang--Ree.
 """
 
 CharTable(order, permutedims(table), classinfo, classlength, charinfo, chardegree,

--- a/data/Tables/G2/G2.103.jl
+++ b/data/Tables/G2/G2.103.jl
@@ -1568,8 +1568,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ a power of $3$, congruent to $3$ modulo $4$.
 
-
-
 - The table was first computed in [Eno76](@cite).
 
 - See also: [CR74](@cite), [Hi90](@cite).

--- a/data/Tables/G2/G2.103.jl
+++ b/data/Tables/G2/G2.103.jl
@@ -1568,7 +1568,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ a power of $3$, congruent to $3$ modulo $4$.
 
-- CHEVIE-name of the table: `G2.10`
+
 
 - The table was first computed in [Eno76](@cite).
 

--- a/data/Tables/G2/G2.103.jl
+++ b/data/Tables/G2/G2.103.jl
@@ -1565,7 +1565,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $\mathrm{G}_2(q)$,
+information = raw"""The generic character table of $\mathrm{G}_2(q)$,
    $q$ a power of $3$, congruent to $3$ modulo $4$.
 
 - CHEVIE-name of the table: `G2.10`

--- a/data/Tables/G2/G2.111.jl
+++ b/data/Tables/G2/G2.111.jl
@@ -1689,7 +1689,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $G_2(q)$,
+information = raw"""The generic character table of $G_2(q)$,
   $q$ odd, congruent to $1$ modulo $3$ and $4$.
 
 - CHEVIE-name of the table: ``G2.11``

--- a/data/Tables/G2/G2.111.jl
+++ b/data/Tables/G2/G2.111.jl
@@ -1692,7 +1692,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $G_2(q)$,
   $q$ odd, congruent to $1$ modulo $3$ and $4$.
 
-- CHEVIE-name of the table: ``G2.11``
+
 
 - The table was first computed in [CR74](@cite).
 

--- a/data/Tables/G2/G2.111.jl
+++ b/data/Tables/G2/G2.111.jl
@@ -1698,21 +1698,24 @@ information = raw"""The generic character table of $G_2(q)$,
 
 - Note:
   Chang's and Ree's notation for the irreducible characters is
-  given in the fourth component of the character information list.
+  given in the third component of the character information list.
 
   Chang's and Ree's notation for the conjugacy classes is given in
-  the fourth component of the class information list.
+  the third component of the class information list.
 
 - Example:
-> PrintInfoChar(``G2.11``,6);
+  ```jldoctest
+  julia> t = generic_character_table("G2.111");
 
-cht   Information
-
-======================================================
-6   [ , [1, 5], [G_2, G_2[1]], X_{18}]
+  julia> info(t[6])
+  3-element Vector{Any}:
+   [1, 5]
+   ["G_2", "G_2[1]"]
+   "X_{18}"
+  ```
 
 - Explanation of example:
-  Character type 6 of G2.11 is called X_{18} by Chang and Ree
+  Character type six of `G2.111` is called $X_{18}$ by Chang and Ree
 """
 
 CharTable(order, permutedims(table), classinfo, classlength, charinfo, chardegree,

--- a/data/Tables/G2/G2.111.jl
+++ b/data/Tables/G2/G2.111.jl
@@ -1692,8 +1692,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $G_2(q)$,
   $q$ odd, congruent to $1$ modulo $3$ and $4$.
 
-
-
 - The table was first computed in [CR74](@cite).
 
 - See also: [Cha68](@cite), [Hi90](@cite).

--- a/data/Tables/G2/G2.113.jl
+++ b/data/Tables/G2/G2.113.jl
@@ -1692,7 +1692,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $G_2(q)$,
   $q$ odd, congruent to $1$ modulo $3$ and $3$ modulo $4$.
 
-- CHEVIE-name of the table: ``G2.11``
+
 
 - The table was first computed in [CR74](@cite).
 

--- a/data/Tables/G2/G2.113.jl
+++ b/data/Tables/G2/G2.113.jl
@@ -1692,8 +1692,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $G_2(q)$,
   $q$ odd, congruent to $1$ modulo $3$ and $3$ modulo $4$.
 
-
-
 - The table was first computed in [CR74](@cite).
 
 - See also: [Cha68](@cite), [Hi90](@cite).

--- a/data/Tables/G2/G2.113.jl
+++ b/data/Tables/G2/G2.113.jl
@@ -1689,7 +1689,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $G_2(q)$,
+information = raw"""The generic character table of $G_2(q)$,
   $q$ odd, congruent to $1$ modulo $3$ and $3$ modulo $4$.
 
 - CHEVIE-name of the table: ``G2.11``

--- a/data/Tables/G2/G2.113.jl
+++ b/data/Tables/G2/G2.113.jl
@@ -1698,21 +1698,24 @@ information = raw"""The generic character table of $G_2(q)$,
 
 - Note:
   Chang's and Ree's notation for the irreducible characters is
-  given in the fourth component of the character information list.
+  given in the third component of the character information list.
 
   Chang's and Ree's notation for the conjugacy classes is given in
-  the fourth component of the class information list.
+  the third component of the class information list.
 
 - Example:
-> PrintInfoChar(``G2.11``,6);
+  ```jldoctest
+  julia> t = generic_character_table("G2.113");
 
-cht   Information
-
-======================================================
-6   [ , [1, 5], [G_2, G_2[1]], X_{18}]
+  julia> info(t[6])
+  3-element Vector{Any}:
+   [1, 5]
+   ["G_2", "G_2[1]"]
+   "X_{18}"
+  ```
 
 - Explanation of example:
-  Character type 6 of G2.11 is called X_{18} by Chang and Ree
+  Character type six of `G2.113` is called $X_{18}$ by Chang and Ree
 """
 
 CharTable(order, permutedims(table), classinfo, classlength, charinfo, chardegree,

--- a/data/Tables/G2/G2.121.jl
+++ b/data/Tables/G2/G2.121.jl
@@ -1689,7 +1689,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $\mathrm{G}_2(q)$,
+information = raw"""The generic character table of $\mathrm{G}_2(q)$,
   $q$ odd, congruent to $2$ modulo $3$ and $1$ modulo $4$.
 
 - CHEVIE-name of the table: `G2.12`

--- a/data/Tables/G2/G2.121.jl
+++ b/data/Tables/G2/G2.121.jl
@@ -1692,7 +1692,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
   $q$ odd, congruent to $2$ modulo $3$ and $1$ modulo $4$.
 
-- CHEVIE-name of the table: `G2.12`
+
 
 - The table was first computed in [CR74](@cite).
 

--- a/data/Tables/G2/G2.121.jl
+++ b/data/Tables/G2/G2.121.jl
@@ -1698,21 +1698,24 @@ information = raw"""The generic character table of $\mathrm{G}_2(q)$,
 
 - Note:
   Chang's and Ree's notation for the irreducible characters is
-  given in the fourth component of the character information list.
+  given in the third component of the character information list.
 
   Chang's and Ree's notation for the conjugacy classes is given in
-  the fourth component of the class information list.
+  the third component of the class information list.
 
 - Example:
-> PrintInfoChar(``G2.12``,6);
+  ```jldoctest
+  julia> t = generic_character_table("G2.121");
 
-cht   Information
-
-======================================================
-6   [ , [1, 5], [G_2, G_2[1]], X_{18}]
+  julia> info(t[6])
+  3-element Vector{Any}:
+   [1, 5]
+   ["G_2", "G_2[1]"]
+   "X_{18}"
+  ```
 
 - Explanation of example:
-  Character type 6 of G2.12 is called X_{18} by Chang and Ree
+  Character type six of `G2.121` is called $X_{18}$ by Chang and Ree
 """
 
 CharTable(order, permutedims(table), classinfo, classlength, charinfo, chardegree,

--- a/data/Tables/G2/G2.121.jl
+++ b/data/Tables/G2/G2.121.jl
@@ -1692,8 +1692,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
   $q$ odd, congruent to $2$ modulo $3$ and $1$ modulo $4$.
 
-
-
 - The table was first computed in [CR74](@cite).
 
 - See also: [Cha68](@cite), [Hi90](@cite).

--- a/data/Tables/G2/G2.123.jl
+++ b/data/Tables/G2/G2.123.jl
@@ -1692,7 +1692,7 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
   $q$ odd, congruent to $2$ modulo $3$ and $3$ modulo $4$.
 
-- CHEVIE-name of the table: `G2.12`
+
 
 - The table was first computed in [CR74](@cite).
 

--- a/data/Tables/G2/G2.123.jl
+++ b/data/Tables/G2/G2.123.jl
@@ -1689,7 +1689,7 @@ charparams = [
 classparamindex = var_index.([i, j])
 charparamindex = var_index.([k, l])
 
-information = raw"""- Information about the generic character table of $\mathrm{G}_2(q)$,
+information = raw"""The generic character table of $\mathrm{G}_2(q)$,
   $q$ odd, congruent to $2$ modulo $3$ and $3$ modulo $4$.
 
 - CHEVIE-name of the table: `G2.12`

--- a/data/Tables/G2/G2.123.jl
+++ b/data/Tables/G2/G2.123.jl
@@ -1692,8 +1692,6 @@ charparamindex = var_index.([k, l])
 information = raw"""The generic character table of $\mathrm{G}_2(q)$,
   $q$ odd, congruent to $2$ modulo $3$ and $3$ modulo $4$.
 
-
-
 - The table was first computed in [CR74](@cite).
 
 - See also: [Cha68](@cite), [Hi90](@cite).

--- a/data/Tables/G2/G2.123.jl
+++ b/data/Tables/G2/G2.123.jl
@@ -1698,21 +1698,24 @@ information = raw"""The generic character table of $\mathrm{G}_2(q)$,
 
 - Note:
   Chang's and Ree's notation for the irreducible characters is
-  given in the fourth component of the character information list.
+  given in the third component of the character information list.
 
   Chang's and Ree's notation for the conjugacy classes is given in
-  the fourth component of the class information list.
+  the third component of the class information list.
 
 - Example:
-> PrintInfoChar(``G2.12``,6);
+  ```jldoctest
+  julia> t = generic_character_table("G2.123");
 
-cht   Information
-
-======================================================
-6   [ , [1, 5], [G_2, G_2[1]], X_{18}]
+  julia> info(t[6])
+  3-element Vector{Any}:
+   [1, 5]
+   ["G_2", "G_2[1]"]
+   "X_{18}"
+  ```
 
 - Explanation of example:
-  Character type 6 of G2.12 is called X_{18} by Chang and Ree
+  Character type six of `G2.123` is called $X_{18}$ by Chang and Ree
 """
 
 CharTable(order, permutedims(table), classinfo, classlength, charinfo, chardegree,

--- a/data/Tables/uniGL/uniGL2.jl
+++ b/data/Tables/uniGL/uniGL2.jl
@@ -25,8 +25,6 @@ chardegree = R.([q, 1])
 
 information = raw"""The unipotent characters for $\mathrm{GL}_2(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGL/uniGL2.jl
+++ b/data/Tables/uniGL/uniGL2.jl
@@ -25,7 +25,7 @@ chardegree = R.([q, 1])
 
 information = raw"""The unipotent characters for $\mathrm{GL}_2(q)$.
 
-- CHEVIE-name of the table: `uniGL2`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGL/uniGL2.jl
+++ b/data/Tables/uniGL/uniGL2.jl
@@ -28,7 +28,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGL2`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGL/uniGL2.jl
+++ b/data/Tables/uniGL/uniGL2.jl
@@ -23,7 +23,7 @@ classtypeorder = R.([q - 1, q - 1, 1//2 * q^2 - 3//2 * q + 1, 1//2 * q^2 - 1//2 
 charinfo = Vector{Any}[[[1, 1]], [[2]]]
 chardegree = R.([q, 1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GL}_2(q)$.
+information = raw"""The unipotent characters for $\mathrm{GL}_2(q)$.
 
 - CHEVIE-name of the table: `uniGL2`
 

--- a/data/Tables/uniGL/uniGL2.jl
+++ b/data/Tables/uniGL/uniGL2.jl
@@ -27,7 +27,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGL2`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGL/uniGL3.jl
+++ b/data/Tables/uniGL/uniGL3.jl
@@ -64,7 +64,7 @@ chardegree = R.([q^3, (q + 1) * q, 1])
 
 information = raw"""The unipotent characters for $\mathrm{GL}_3(q)$.
 
-- CHEVIE-name of the table: `uniGL3`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGL/uniGL3.jl
+++ b/data/Tables/uniGL/uniGL3.jl
@@ -64,8 +64,6 @@ chardegree = R.([q^3, (q + 1) * q, 1])
 
 information = raw"""The unipotent characters for $\mathrm{GL}_3(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGL/uniGL3.jl
+++ b/data/Tables/uniGL/uniGL3.jl
@@ -67,7 +67,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGL3`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGL/uniGL3.jl
+++ b/data/Tables/uniGL/uniGL3.jl
@@ -66,7 +66,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGL3`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGL/uniGL3.jl
+++ b/data/Tables/uniGL/uniGL3.jl
@@ -62,7 +62,7 @@ classtypeorder =
 charinfo = Vector{Any}[[[1, 1, 1]], [[2, 1]], [[3]]]
 chardegree = R.([q^3, (q + 1) * q, 1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GL}_3(q)$.
+information = raw"""The unipotent characters for $\mathrm{GL}_3(q)$.
 
 - CHEVIE-name of the table: `uniGL3`
 

--- a/data/Tables/uniGL/uniGL4.jl
+++ b/data/Tables/uniGL/uniGL4.jl
@@ -202,7 +202,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGL4`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGL/uniGL4.jl
+++ b/data/Tables/uniGL/uniGL4.jl
@@ -201,7 +201,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGL4`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGL/uniGL4.jl
+++ b/data/Tables/uniGL/uniGL4.jl
@@ -199,8 +199,6 @@ chardegree = R.([q^6, q^3 * (q^2 + q + 1), q^2 * (q^2 + 1), q * (q^2 + q + 1), 1
 
 information = raw"""The unipotent characters for $\mathrm{GL}_4(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGL/uniGL4.jl
+++ b/data/Tables/uniGL/uniGL4.jl
@@ -199,7 +199,7 @@ chardegree = R.([q^6, q^3 * (q^2 + q + 1), q^2 * (q^2 + 1), q * (q^2 + q + 1), 1
 
 information = raw"""The unipotent characters for $\mathrm{GL}_4(q)$.
 
-- CHEVIE-name of the table: `uniGL4`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGL/uniGL4.jl
+++ b/data/Tables/uniGL/uniGL4.jl
@@ -197,7 +197,7 @@ classtypeorder =
 charinfo = Vector{Any}[[[1, 1, 1, 1]], [[2, 1, 1]], [[2, 2]], [[3, 1]], [[4]]]
 chardegree = R.([q^6, q^3 * (q^2 + q + 1), q^2 * (q^2 + 1), q * (q^2 + q + 1), 1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GL}_4(q)$.
+information = raw"""The unipotent characters for $\mathrm{GL}_4(q)$.
 
 - CHEVIE-name of the table: `uniGL4`
 

--- a/data/Tables/uniGL/uniGL5.jl
+++ b/data/Tables/uniGL/uniGL5.jl
@@ -460,7 +460,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGL5`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGL/uniGL5.jl
+++ b/data/Tables/uniGL/uniGL5.jl
@@ -459,7 +459,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGL5`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGL/uniGL5.jl
+++ b/data/Tables/uniGL/uniGL5.jl
@@ -455,7 +455,7 @@ chardegree =
     q * (q + 1) * (q^2 + 1),
     1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GL}_5(q)$.
+information = raw"""The unipotent characters for $\mathrm{GL}_5(q)$.
 
 - CHEVIE-name of the table: `uniGL5`
 

--- a/data/Tables/uniGL/uniGL5.jl
+++ b/data/Tables/uniGL/uniGL5.jl
@@ -457,8 +457,6 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GL}_5(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGL/uniGL5.jl
+++ b/data/Tables/uniGL/uniGL5.jl
@@ -457,7 +457,7 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GL}_5(q)$.
 
-- CHEVIE-name of the table: `uniGL5`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGL/uniGL6.jl
+++ b/data/Tables/uniGL/uniGL6.jl
@@ -1702,7 +1702,7 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GL}_6(q)$.
 
-- CHEVIE-name of the table: `uniGL6`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGL/uniGL6.jl
+++ b/data/Tables/uniGL/uniGL6.jl
@@ -1704,7 +1704,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGL6`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGL/uniGL6.jl
+++ b/data/Tables/uniGL/uniGL6.jl
@@ -1702,8 +1702,6 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GL}_6(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGL/uniGL6.jl
+++ b/data/Tables/uniGL/uniGL6.jl
@@ -1700,7 +1700,7 @@ chardegree =
     q * (q^4 + q^3 + q^2 + q + 1),
     1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GL}_6(q)$.
+information = raw"""The unipotent characters for $\mathrm{GL}_6(q)$.
 
 - CHEVIE-name of the table: `uniGL6`
 

--- a/data/Tables/uniGL/uniGL6.jl
+++ b/data/Tables/uniGL/uniGL6.jl
@@ -1705,7 +1705,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGL6`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGL/uniGL7.jl
+++ b/data/Tables/uniGL/uniGL7.jl
@@ -4162,7 +4162,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGL7`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGL/uniGL7.jl
+++ b/data/Tables/uniGL/uniGL7.jl
@@ -4159,8 +4159,6 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GL}_7(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGL/uniGL7.jl
+++ b/data/Tables/uniGL/uniGL7.jl
@@ -4161,7 +4161,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGL7`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGL/uniGL7.jl
+++ b/data/Tables/uniGL/uniGL7.jl
@@ -4159,7 +4159,7 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GL}_7(q)$.
 
-- CHEVIE-name of the table: `uniGL7`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGL/uniGL7.jl
+++ b/data/Tables/uniGL/uniGL7.jl
@@ -4157,7 +4157,7 @@ chardegree =
     q * (q + 1) * (q^2 + q + 1) * (q^2 - q + 1),
     1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GL}_7(q)$.
+information = raw"""The unipotent characters for $\mathrm{GL}_7(q)$.
 
 - CHEVIE-name of the table: `uniGL7`
 

--- a/data/Tables/uniGL/uniGL8.jl
+++ b/data/Tables/uniGL/uniGL8.jl
@@ -13476,7 +13476,7 @@ chardegree =
     q * (q^6 + q^5 + q^4 + q^3 + q^2 + q + 1),
     1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GL}_8(q)$.
+information = raw"""The unipotent characters for $\mathrm{GL}_8(q)$.
 
 - CHEVIE-name of the table: `uniGL8`
 

--- a/data/Tables/uniGL/uniGL8.jl
+++ b/data/Tables/uniGL/uniGL8.jl
@@ -13478,8 +13478,6 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GL}_8(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGL/uniGL8.jl
+++ b/data/Tables/uniGL/uniGL8.jl
@@ -13481,7 +13481,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGL8`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGL/uniGL8.jl
+++ b/data/Tables/uniGL/uniGL8.jl
@@ -13478,7 +13478,7 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GL}_8(q)$.
 
-- CHEVIE-name of the table: `uniGL8`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGL/uniGL8.jl
+++ b/data/Tables/uniGL/uniGL8.jl
@@ -13480,7 +13480,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGL8`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGU/uniGU2.jl
+++ b/data/Tables/uniGU/uniGU2.jl
@@ -28,7 +28,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGU2`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGU/uniGU2.jl
+++ b/data/Tables/uniGU/uniGU2.jl
@@ -25,7 +25,7 @@ chardegree = R.([q, 1])
 
 information = raw"""The unipotent characters for $\mathrm{GU}_2(q)$.
 
-- CHEVIE-name of the table: `uniGU2`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGU/uniGU2.jl
+++ b/data/Tables/uniGU/uniGU2.jl
@@ -27,7 +27,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGU2`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGU/uniGU2.jl
+++ b/data/Tables/uniGU/uniGU2.jl
@@ -25,8 +25,6 @@ chardegree = R.([q, 1])
 
 information = raw"""The unipotent characters for $\mathrm{GU}_2(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGU/uniGU2.jl
+++ b/data/Tables/uniGU/uniGU2.jl
@@ -23,7 +23,7 @@ classtypeorder = R.([q + 1, q + 1, 1//2 * q^2 - 1//2 * q - 1, 1//2 * q^2 + 1//2 
 charinfo = Vector{Any}[[[1, 1]], [[2]]]
 chardegree = R.([q, 1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GU}_2(q)$.
+information = raw"""The unipotent characters for $\mathrm{GU}_2(q)$.
 
 - CHEVIE-name of the table: `uniGU2`
 

--- a/data/Tables/uniGU/uniGU3.jl
+++ b/data/Tables/uniGU/uniGU3.jl
@@ -64,8 +64,6 @@ chardegree = R.([q^3, (q - 1) * q, 1])
 
 information = raw"""The unipotent characters for $\mathrm{GU}_3(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGU/uniGU3.jl
+++ b/data/Tables/uniGU/uniGU3.jl
@@ -67,7 +67,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGU3`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGU/uniGU3.jl
+++ b/data/Tables/uniGU/uniGU3.jl
@@ -64,7 +64,7 @@ chardegree = R.([q^3, (q - 1) * q, 1])
 
 information = raw"""The unipotent characters for $\mathrm{GU}_3(q)$.
 
-- CHEVIE-name of the table: `uniGU3`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGU/uniGU3.jl
+++ b/data/Tables/uniGU/uniGU3.jl
@@ -62,7 +62,7 @@ classtypeorder =
 charinfo = Vector{Any}[[[1, 1, 1]], [[2, 1]], [[3]]]
 chardegree = R.([q^3, (q - 1) * q, 1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GU}_3(q)$.
+information = raw"""The unipotent characters for $\mathrm{GU}_3(q)$.
 
 - CHEVIE-name of the table: `uniGU3`
 

--- a/data/Tables/uniGU/uniGU3.jl
+++ b/data/Tables/uniGU/uniGU3.jl
@@ -66,7 +66,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGU3`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGU/uniGU4.jl
+++ b/data/Tables/uniGU/uniGU4.jl
@@ -199,7 +199,7 @@ chardegree = R.([q^6, (q^2 - q + 1) * q^3, q^2 * (q^2 + 1), q * (q^2 - q + 1), 1
 
 information = raw"""The unipotent characters for $\mathrm{GU}_4(q)$.
 
-- CHEVIE-name of the table: `uniGU4`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGU/uniGU4.jl
+++ b/data/Tables/uniGU/uniGU4.jl
@@ -202,7 +202,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGU4`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGU/uniGU4.jl
+++ b/data/Tables/uniGU/uniGU4.jl
@@ -201,7 +201,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGU4`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGU/uniGU4.jl
+++ b/data/Tables/uniGU/uniGU4.jl
@@ -199,8 +199,6 @@ chardegree = R.([q^6, (q^2 - q + 1) * q^3, q^2 * (q^2 + 1), q * (q^2 - q + 1), 1
 
 information = raw"""The unipotent characters for $\mathrm{GU}_4(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGU/uniGU4.jl
+++ b/data/Tables/uniGU/uniGU4.jl
@@ -197,7 +197,7 @@ classtypeorder =
 charinfo = Vector{Any}[[[1, 1, 1, 1]], [[2, 1, 1]], [[2, 2]], [[3, 1]], [[4]]]
 chardegree = R.([q^6, (q^2 - q + 1) * q^3, q^2 * (q^2 + 1), q * (q^2 - q + 1), 1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GU}_4(q)$.
+information = raw"""The unipotent characters for $\mathrm{GU}_4(q)$.
 
 - CHEVIE-name of the table: `uniGU4`
 

--- a/data/Tables/uniGU/uniGU5.jl
+++ b/data/Tables/uniGU/uniGU5.jl
@@ -457,7 +457,7 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GU}_5(q)$.
 
-- CHEVIE-name of the table: `uniGU5`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGU/uniGU5.jl
+++ b/data/Tables/uniGU/uniGU5.jl
@@ -460,7 +460,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGU5`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGU/uniGU5.jl
+++ b/data/Tables/uniGU/uniGU5.jl
@@ -457,8 +457,6 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GU}_5(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGU/uniGU5.jl
+++ b/data/Tables/uniGU/uniGU5.jl
@@ -455,7 +455,7 @@ chardegree =
     q * (q - 1) * (q^2 + 1),
     1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GU}_5(q)$.
+information = raw"""The unipotent characters for $\mathrm{GU}_5(q)$.
 
 - CHEVIE-name of the table: `uniGU5`
 

--- a/data/Tables/uniGU/uniGU5.jl
+++ b/data/Tables/uniGU/uniGU5.jl
@@ -459,7 +459,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGU5`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGU/uniGU6.jl
+++ b/data/Tables/uniGU/uniGU6.jl
@@ -1701,8 +1701,6 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GU}_6(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGU/uniGU6.jl
+++ b/data/Tables/uniGU/uniGU6.jl
@@ -1701,7 +1701,7 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GU}_6(q)$.
 
-- CHEVIE-name of the table: `uniGU6`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGU/uniGU6.jl
+++ b/data/Tables/uniGU/uniGU6.jl
@@ -1703,7 +1703,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGU6`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGU/uniGU6.jl
+++ b/data/Tables/uniGU/uniGU6.jl
@@ -1699,7 +1699,7 @@ chardegree =
     q * (q^4 - q^3 + q^2 - q + 1),
     1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GU}_6(q)$.
+information = raw"""The unipotent characters for $\mathrm{GU}_6(q)$.
 
 - CHEVIE-name of the table: `uniGU6`
 

--- a/data/Tables/uniGU/uniGU6.jl
+++ b/data/Tables/uniGU/uniGU6.jl
@@ -1704,7 +1704,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGU6`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGU/uniGU7.jl
+++ b/data/Tables/uniGU/uniGU7.jl
@@ -4158,7 +4158,7 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GU}_7(q)$.
 
-- CHEVIE-name of the table: `uniGU7`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGU/uniGU7.jl
+++ b/data/Tables/uniGU/uniGU7.jl
@@ -4156,7 +4156,7 @@ chardegree =
     q * (q - 1) * (q^2 - q + 1) * (q^2 + q + 1),
     1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GU}_7(q)$.
+information = raw"""The unipotent characters for $\mathrm{GU}_7(q)$.
 
 - CHEVIE-name of the table: `uniGU7`
 

--- a/data/Tables/uniGU/uniGU7.jl
+++ b/data/Tables/uniGU/uniGU7.jl
@@ -4160,7 +4160,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGU7`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGU/uniGU7.jl
+++ b/data/Tables/uniGU/uniGU7.jl
@@ -4161,7 +4161,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGU7`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGU/uniGU7.jl
+++ b/data/Tables/uniGU/uniGU7.jl
@@ -4158,8 +4158,6 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GU}_7(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/data/Tables/uniGU/uniGU8.jl
+++ b/data/Tables/uniGU/uniGU8.jl
@@ -13473,7 +13473,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 
 - CHEVIE-name of the table: `uniGU8`
 
-- This table is computed with general programs written by F.Luebeck.
+- This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """

--- a/data/Tables/uniGU/uniGU8.jl
+++ b/data/Tables/uniGU/uniGU8.jl
@@ -13469,7 +13469,7 @@ chardegree =
     q * (q^6 - q^5 + q^4 - q^3 + q^2 - q + 1),
     1])
 
-information = raw"""- Information about the tables of unipotent characters for $\mathrm{GU}_8(q)$.
+information = raw"""The unipotent characters for $\mathrm{GU}_8(q)$.
 
 - CHEVIE-name of the table: `uniGU8`
 

--- a/data/Tables/uniGU/uniGU8.jl
+++ b/data/Tables/uniGU/uniGU8.jl
@@ -13474,7 +13474,7 @@ information = raw"""- Information about the tables of unipotent characters for $
 - CHEVIE-name of the table: `uniGU8`
 
 - This table is computed with general programs written by F.Luebeck.
-  They compute the Deligne-Lusztig characters R_T^G(1) and find the
+  They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.
 """
 

--- a/data/Tables/uniGU/uniGU8.jl
+++ b/data/Tables/uniGU/uniGU8.jl
@@ -13471,7 +13471,7 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GU}_8(q)$.
 
-- CHEVIE-name of the table: `uniGU8`
+
 
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the

--- a/data/Tables/uniGU/uniGU8.jl
+++ b/data/Tables/uniGU/uniGU8.jl
@@ -13471,8 +13471,6 @@ chardegree =
 
 information = raw"""The unipotent characters for $\mathrm{GU}_8(q)$.
 
-
-
 - This table is computed with general programs written by F. Lübeck.
   They compute the Deligne-Lusztig characters $R_T^G(1)$ and find the
   unipotent characters as linear combinations of them.

--- a/docs/generate_overview.jl
+++ b/docs/generate_overview.jl
@@ -3,35 +3,37 @@ using GenericCharacterTables
 
 println("@__DIR__")
 
-tabletype = "Tables"
 path = joinpath(@__DIR__, "..", "data")
-table_types = readdir("$path/$tabletype")
 
-open(joinpath(@__DIR__, "src", "tables_list.md"), "w") do out
-  println(out, """
-               ```@meta
-               CurrentModule = GenericCharacterTables
-               DocTestSetup = :(using GenericCharacterTables, Oscar)
-               ```
-               
-               # List of tables
-               """)
-  for tt in table_types
-    println("# Table type $tt")
-    # TODO: provide a map from table types to "nice" versisons, e.g. `2A2` -> `{}^2A_2`
+for (tabletype, header, filename) in (("Tables", "tables", "tables_list.md"), ("Greenfunctions", "Green functions", "greenfunctions_list.md"))
+  open(joinpath(@__DIR__, "src", filename), "w") do out
+    println("# List of $header")
     println(out, """
-                 ## Table type $tt
+                 ```@meta
+                 CurrentModule = GenericCharacterTables
+                 DocTestSetup = :(using GenericCharacterTables, Oscar)
+                 ```
+                 
+                 # List of $header
                  """)
-
-    tables = [replace(x, ".jl" => "") for x in readdir("$path/$tabletype/$tt")]
-    for name in tables
-      println("- Table $tt/$name")
+    table_types = readdir("$path/$tabletype")
+    for tt in table_types
+      println("# Table type $tt")
+      # TODO: provide a map from table types to "nice" versisons, e.g. `2A2` -> `{}^2A_2`
       println(out, """
-                   ### Table `$name`
+                   ## Table type $tt
                    """)
-      g = generic_character_table(name)
-      println(out, g.information)
-      println(out)
+
+      tables = [replace(x, ".jl" => "") for x in readdir("$path/$tabletype/$tt")]
+      for name in tables
+        println("- Table $tt/$name")
+        println(out, """
+                     ### Table `$name`
+                     """)
+        g = generic_character_table(name)
+        println(out, g.information)
+        println(out)
+      end
     end
   end
 end

--- a/docs/generate_overview.jl
+++ b/docs/generate_overview.jl
@@ -5,7 +5,8 @@ println("@__DIR__")
 
 path = joinpath(@__DIR__, "..", "data")
 
-for (tabletype, header, filename) in (("Tables", "tables", "tables_list.md"), ("Greenfunctions", "Green functions", "greenfunctions_list.md"))
+for (tabletype, header, filename, loader) in (("Tables", "tables", "tables_list.md", generic_character_table),
+        ("Greenfunctions", "Green functions", "greenfunctions_list.md", green_function_table))
   open(joinpath(@__DIR__, "src", filename), "w") do out
     println("# List of $header")
     println(out, """
@@ -30,7 +31,7 @@ for (tabletype, header, filename) in (("Tables", "tables", "tables_list.md"), ("
         println(out, """
                      ### Table `$name`
                      """)
-        g = generic_character_table(name)
+        g = loader(name)
         println(out, g.information)
         println(out)
       end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -37,6 +37,7 @@ makedocs(;
     "printing.md",
     "unexported.md",
     "tables_list.md",
+    "greenfunctions_list.md",
     "references.md",
   ],
   plugins=[bib],

--- a/src/CharTable.jl
+++ b/src/CharTable.jl
@@ -166,9 +166,7 @@ Return the metadata of `t` in LaTeX format. This usually includes the time the t
 julia> g=generic_character_table("GL2");
 
 julia> info(g)
-    •  Information about the generic character table of \mathrm{GL}_2(q).
-
-    •  CHEVIE-name of the table: GL2
+    •  The generic character table of \mathrm{GL}_2(q).
 
     •  The table was first computed in Jor07 (@cite), Sch07 (@cite).
 

--- a/src/CharTable.jl
+++ b/src/CharTable.jl
@@ -166,7 +166,7 @@ Return the metadata of `t` in LaTeX format. This usually includes the time the t
 julia> g=generic_character_table("GL2");
 
 julia> info(g)
-    •  The generic character table of \mathrm{GL}_2(q).
+  The generic character table of \mathrm{GL}_2(q).
 
     •  The table was first computed in Jor07 (@cite), Sch07 (@cite).
 


### PR DESCRIPTION
TODOs:
- [x] get rid of the `CHEVIE-name of the table ...` lines
- [ ] maybe turn everything from a "list" into a simple text...
- [x] replace `- Information about the generic table` by just "The generic table" ?
- [x] patch up more of the examples
- [x] replace `F.Luebeck` by `F. Lübeck` (or `Frank Lübeck`)
- [x] also show the content of `data/Greenfunctions` (perhaps on a separate page???)
- [x] wrap `R_T^G(1)` into math mode: $R_T^G(1)$