### PR TITLE
CI: add statuses permissions for doc preview link

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   actions: write
   contents: read
+  statuses: write
 
 concurrency:
   # group by workflow and ref; the last slightly strange component ensures that for pull


### PR DESCRIPTION
This should allow the documenter job to add the status with the preview link.

x-ref: https://github.com/oscar-system/GenericCharacterTables.jl/pull/294#issuecomment-2904421205
cc: @fingolfin 

_edit:_
![docs](https://github.com/user-attachments/assets/107f3daf-1883-49c5-9870-8f6139f87ac7)
