### PR TITLE
Specialization to ordinary table

### DIFF
--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -9,6 +9,7 @@ export evaluate
 export factor_cyclotomic
 export generic_character_table
 export generic_cyclotomic_ring
+export get_ordinary
 export green_function_table
 export info
 export kempner

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -8,6 +8,7 @@ export evaluate
 export factor_cyclotomic
 export generic_character_table
 export generic_cyclotomic_ring
+export get_ordinary
 export green_function_table
 export info
 export kempner

--- a/src/GenericCharacterTables.jl
+++ b/src/GenericCharacterTables.jl
@@ -37,5 +37,6 @@ include("Congruence.jl")
 include("Exports.jl")
 include("Deprecations.jl")
 include("CyclotomicFac.jl")
+include("GetOrdinary.jl")
 
 end

--- a/src/GetOrdinary.jl
+++ b/src/GetOrdinary.jl
@@ -13,17 +13,16 @@ function get_ordinary(char::GenericCharacter, val)
   params = parameters(char)
   exceptions = params.exceptions
   ranges = UnitRange{Int64}[]
-  vars = Int64[]
+  vars = Int64[1]
   for param in params
     push!(vars, var_index(param.var))
     upper = evaluate(param.modulus, [q], [val])
     push!(ranges, 1:numerator(constant_coefficient(upper)))
   end
-  spec = specialize(char, q, val)
   for vals in Iterators.product(ranges...)
-    vals = collect(vals)
+    vals = collect((val, vals...))
     if !exceptions_apply(exceptions, vars, vals)
-      ordinary_char = evaluate.(spec.values, Ref(vars), Ref(vals))
+      ordinary_char = evaluate.(char.values, Ref(vars), Ref(vals))
       push!(ordinary_chars, ordinary_char)
     end
   end
@@ -46,14 +45,14 @@ function get_ordinary(table::CharTable, val)
     params = parameters(table[:,class])
     exceptions = params.exceptions
     ranges = UnitRange{Int64}[]
-    vars = Int64[]
+    vars = Int64[1]
     for param in params
       push!(vars, var_index(param.var))
       upper = evaluate(param.modulus, [q], [val])
       push!(ranges, 1:numerator(constant_coefficient(upper)))
     end
     for vals in Iterators.product(ranges...)
-      vals = collect(vals)
+      vals = collect((val, vals...))
       if !exceptions_apply(exceptions, vars, vals)
         for (i, ordinary_char) in enumerate(ordinary_chars)
           push!(ordinary_table[i], evaluate(ordinary_char[class], vars, vals))

--- a/src/GetOrdinary.jl
+++ b/src/GetOrdinary.jl
@@ -1,0 +1,65 @@
+function exceptions_apply(exceptions, vars, vals)
+  for exception in exceptions
+    if is_integer(evaluate(exception, vars, vals))
+      return true
+    end
+  end
+  return false
+end
+
+function get_ordinary(char::GenericCharacter, val)
+  ordinary_chars = []
+  q = parameters(parent(char))[1]
+  params = parameters(char)
+  exceptions = params.exceptions
+  ranges = UnitRange{Int64}[]
+  vars = Int64[]
+  for param in params
+    push!(vars, var_index(param.var))
+    upper = evaluate(param.modulus, [q], [val])
+    push!(ranges, 1:numerator(constant_coefficient(upper)))
+  end
+  spec = specialize(char, q, val)
+  for vals in Iterators.product(ranges...)
+    vals = collect(vals)
+    if !exceptions_apply(exceptions, vars, vals)
+      ordinary_char = evaluate.(spec.values, Ref(vars), Ref(vals))
+      push!(ordinary_chars, ordinary_char)
+    end
+  end
+  return ordinary_chars
+end
+
+function get_ordinary(table::CharTable, val)
+  q = parameters(table)[1]
+  ordinary_chars = []
+  for char in table
+    for ordinary_char in get_ordinary(char, val)
+      push!(ordinary_chars, ordinary_char)
+    end
+  end
+  ordinary_table = []
+  for _ in ordinary_chars
+    push!(ordinary_table, [])
+  end
+  for class in 1:number_of_conjugacy_class_types(table)
+    params = parameters(table[:,class])
+    exceptions = params.exceptions
+    ranges = UnitRange{Int64}[]
+    vars = Int64[]
+    for param in params
+      push!(vars, var_index(param.var))
+      upper = evaluate(param.modulus, [q], [val])
+      push!(ranges, 1:numerator(constant_coefficient(upper)))
+    end
+    for vals in Iterators.product(ranges...)
+      vals = collect(vals)
+      if !exceptions_apply(exceptions, vars, vals)
+        for (i, ordinary_char) in enumerate(ordinary_chars)
+          push!(ordinary_table[i], evaluate(ordinary_char[class], vars, vals))
+        end
+      end
+    end
+  end
+  return transpose(unique(unique(hcat(ordinary_table...), dims=1), dims=2))
+end


### PR DESCRIPTION
This is a first and very crude hack to get an ordinary character table from a generic one. Apparently I'm doing something wrong or the parameter specifications of `GL2` are incorrect. This is what I get for $\mathrm{GL}(2,3)$:
```
julia> g=generic_character_table("GL2")
Generic character table GL2
  of order q^4 - q^3 - q^2 + q
  with 4 irreducible character types
  with 4 class types
  with parameters (i, j, l, k)

julia> get_ordinary(g, 3)
10×10 transpose(::Matrix{GenericCharacterTables.GenericCyclo}) with eltype GenericCharacterTables.GenericCyclo:
 1   1  1   1   -1  -1              1   1   -1              1
 1   1  1   1   1   1               1   1   1               1
 3   3  0   0   -1  1               -1  -1  1               -1
 3   3  0   0   1   -1              -1  -1  -1              -1
 -4  4  -1  1   0   0               0   0   0               0
 -2  2  1   -1  0   -E(8) - E(8)^3  0   2   E(8) + E(8)^3   -2
 2   2  -1  -1  0   0               2   -2  0               -2
 2   2  -1  -1  0   2               -2  -2  2               -2
 -2  2  1   -1  0   E(8) + E(8)^3   0   2   -E(8) - E(8)^3  -2
 2   2  -1  -1  0   -2              -2  -2  -2              -2

```

There are two additional rows and columns as can be verified [here](https://ncatlab.org/nlab/show/character+table+of+GL%282%2C3%29).