### PR TITLE
Remove broken markdown from greenfunction tables

### DIFF
--- a/data/Greenfunctions/2A2/GU3.jl
+++ b/data/Greenfunctions/2A2/GU3.jl
@@ -28,10 +28,6 @@ information = raw"""The Green functions of $\mathrm{GU}_3(q)$.
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).
 
 - See also: [DM87*1](@cite).
-
-- For the computation of the Green functions for $\mathrm{GL}_n(q)$ see for example:
-  > GreenFunTab(GL2);
-  > PrintInfoTab(GL2green);
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/2A3/GU4.jl
+++ b/data/Greenfunctions/2A3/GU4.jl
@@ -55,10 +55,6 @@ information = raw"""The Green functions of $\mathrm{GU}_4(q)$.
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).
 
 - See also: [DM87*1](@cite).
-
-- For the computation of the Green functions for $\mathrm{GL}_n(q)$ see for example:
-  > GreenFunTab(GL2);
-  > PrintInfoTab(GL2green);
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/2A4/GU5.jl
+++ b/data/Greenfunctions/2A4/GU5.jl
@@ -93,10 +93,6 @@ information = raw"""The Green functions of $\mathrm{GU}_5(q)$.
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).
 
 - See also: [DM87*1](@cite).
-
-- For the computation of the Green functions for $\mathrm{GL}_n(q)$ see for example:
-  > GreenFunTab(GL2);
-  > PrintInfoTab(GL2green);
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/2A5/GU6.jl
+++ b/data/Greenfunctions/2A5/GU6.jl
@@ -204,10 +204,6 @@ information = raw"""The Green functions of $\mathrm{GU}_6(q)$.
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).
 
 - See also: [DM87*1](@cite).
-
-- For the computation of the Green functions for $\mathrm{GL}_n(q)$ see for example:
-  > GreenFunTab(GL2);
-  > PrintInfoTab(GL2green);
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/2A6/GU7.jl
+++ b/data/Greenfunctions/2A6/GU7.jl
@@ -364,10 +364,6 @@ information = raw"""The Green functions of $\mathrm{GU}_7(q)$.
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).
 
 - See also: [DM87*1](@cite).
-
-- For the computation of the Green functions for $\mathrm{GL}_n(q)$ see for example:
-  > GreenFunTab(GL2);
-  > PrintInfoTab(GL2green);
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/2A7/GU8.jl
+++ b/data/Greenfunctions/2A7/GU8.jl
@@ -784,10 +784,6 @@ information = raw"""The Green functions of $\mathrm{GU}_8(q^2)$.
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).
 
 - See also: [DM87*1](@cite).
-
-- For the computation of the Green functions for $\mathrm{GL}_n(q)$ see for example:
-  > GreenFunTab(GL2);
-  > PrintInfoTab(GL2green);
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/2A8/GU9.jl
+++ b/data/Greenfunctions/2A8/GU9.jl
@@ -1610,10 +1610,6 @@ information = raw"""The Green functions of $\mathrm{GU}_9(q)$.
   by substituting $q$ by $-q$. This is proved in [HS77](@cite) and [Kaw85](@cite).
 
 - See also: [DM87*1](@cite).
-
-- For the computation of the Green functions for $\mathrm{GL}_n(q)$ see for example:
-  > GreenFunTab(GL2);
-  > PrintInfoTab(GL2green);
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A0/GL1.jl
+++ b/data/Greenfunctions/A0/GL1.jl
@@ -18,14 +18,6 @@ information = raw"""The Green functions of $\mathrm{GL}_1(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A1/GL2.jl
+++ b/data/Greenfunctions/A1/GL2.jl
@@ -22,14 +22,6 @@ information = raw"""The Green functions of $\mathrm{GL}_2(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A10/GL11.jl
+++ b/data/Greenfunctions/A10/GL11.jl
@@ -7749,14 +7749,6 @@ information = raw"""The Green functions of $\mathrm{GL}_11(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A2/GL3.jl
+++ b/data/Greenfunctions/A2/GL3.jl
@@ -28,14 +28,6 @@ information = raw"""The Green functions of $\mathrm{GL}_3(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A3/GL4.jl
+++ b/data/Greenfunctions/A3/GL4.jl
@@ -55,14 +55,6 @@ information = raw"""The Green functions of $\mathrm{GL}_4(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A4/GL5.jl
+++ b/data/Greenfunctions/A4/GL5.jl
@@ -93,14 +93,6 @@ information = raw"""The Green functions of $\mathrm{GL}_5(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A5/GL6.jl
+++ b/data/Greenfunctions/A5/GL6.jl
@@ -204,14 +204,6 @@ information = raw"""The Green functions of $\mathrm{GL}_6(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A6/GL7.jl
+++ b/data/Greenfunctions/A6/GL7.jl
@@ -363,14 +363,6 @@ information = raw"""The Green functions of $\mathrm{GL}_7(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A7/GL8.jl
+++ b/data/Greenfunctions/A7/GL8.jl
@@ -789,14 +789,6 @@ information = raw"""The Green functions of $\mathrm{GL}_8(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A8/GL9.jl
+++ b/data/Greenfunctions/A8/GL9.jl
@@ -1614,14 +1614,6 @@ information = raw"""The Green functions of $\mathrm{GL}_9(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(

--- a/data/Greenfunctions/A9/GL10.jl
+++ b/data/Greenfunctions/A9/GL10.jl
@@ -3664,14 +3664,6 @@ information = raw"""The Green functions of $\mathrm{GL}_10(q)$.
 - See also: [Ste51](@cite).
 
 - This CHEVIE-table is computed by an algorithm from [LS78](@cite).
-
-- The program which generates the files with the Green functions 
-  of $\mathrm{GL}_n(q)$ and $\mathrm{GU}_n(q)$ is part of the CHEVIE-system. You 
-  can reproduce them with the CHEVIE commands: 
-  > GreenFunctionsA(n,filename);
-  > GreenFunctions2A(n,filename);
-  (see the corresponding help)
-  These programs are written by U. Porsch and F. Lübeck.
 """
 
 SimpleCharTable(


### PR DESCRIPTION
I looked through the greenfunction info strings again. The issues with the markdown are mostly related to the `GreenFunctionsA` and `GreenFunctionsA2` functions from the original CHEVIE which are still missing in this project. I think when they are implemented here as well we should mention them at the docs separately and maybe readd them to the info strings of the tables I removed them from with this PR.

However one issue remains I'm not sure how to resolve. I don't understand the info string of `2D4n2`. So, I'm struggling to translate it to valid markdown. @fingolfin Perhaps you know what the string means?