### PR TITLE
Add missing exceptions to SL3.n1

### DIFF
--- a/data/Tables/A2/SL3.n1.jl
+++ b/data/Tables/A2/SL3.n1.jl
@@ -233,7 +233,7 @@ classparams = [
   Parameters(Parameter[]),
   Parameters([Parameter(a, q - 1)], [((a) * 1//(q - 1))]),
   Parameters([Parameter(a, q - 1)], [((a) * 1//(q - 1))]),
-  Parameters([Parameter(a, q - 1), Parameter(b, q - 1)], [((a - b) * 1//(q - 1))]),
+  Parameters([Parameter(a, q - 1), Parameter(b, q - 1)], [((a - b) * 1//(q - 1)), ((a + 2*b) * 1//(q - 1)), ((2*a + b) * 1//(q - 1))]),
   Parameters([Parameter(a, q^2 - 1)], [((a) * 1//(q + 1))]),
   Parameters([Parameter(a, q^2 + q + 1)], [((a) * 1//(q^2 + q + 1))]),
 ]
@@ -244,7 +244,7 @@ charparams = [
   Parameters(Parameter[]),
   Parameters([Parameter(n, q - 1)], [((n) * 1//(q - 1))]),
   Parameters([Parameter(n, q - 1)], [((n) * 1//(q - 1))]),
-  Parameters([Parameter(n, q - 1), Parameter(m, q - 1)], [((n - m) * 1//(q - 1))]),
+  Parameters([Parameter(n, q - 1), Parameter(m, q - 1)], [((n - m) * 1//(q - 1)), ((n + 2*m) * 1//(q - 1)), ((2*n + m) * 1//(q - 1))]),
   Parameters([Parameter(n, q^2 - 1)], [((n) * 1//(q + 1))]),
   Parameters([Parameter(n, q^2 + q + 1)], [((n) * 1//(q^2 + q + 1))]),
 ]

--- a/data/Tables/A2/SL3.n1.jl
+++ b/data/Tables/A2/SL3.n1.jl
@@ -244,7 +244,7 @@ charparams = [
   Parameters(Parameter[]),
   Parameters([Parameter(n, q - 1)], [((n) * 1//(q - 1))]),
   Parameters([Parameter(n, q - 1)], [((n) * 1//(q - 1))]),
-  Parameters([Parameter(n, q - 1), Parameter(m, q - 1)], [((n - m) * 1//(q - 1)), ((n + 2*m) * 1//(q - 1)), ((2*n + m) * 1//(q - 1))]),
+  Parameters([Parameter(n, q - 1), Parameter(m, q - 1)], [((n - m) * 1//(q - 1)), ((n) * 1//(q - 1)), ((m) * 1//(q - 1))]),
   Parameters([Parameter(n, q^2 - 1)], [((n) * 1//(q + 1))]),
   Parameters([Parameter(n, q^2 + q + 1)], [((n) * 1//(q^2 + q + 1))]),
 ]


### PR DESCRIPTION
While working through the [extended example](https://oscar-system.github.io/GenericCharacterTables.jl/dev/book/) from the docs, one might wonder if the given decomposition is actually correct. Besides checking the degree it is also intersting to see if the values on all classes coincide with the tensor product. On the conjugacy classes of type 6 the tensor product has value $4$. The partial sum consisting of the first three irreducible character types has the value $7$. So the two "generic" sums consisting of the character types 6 and 7 should have a value of $-3$. The sum of character type 7 has value $0$. Checking the sum of character type 6 we get:
```
GenericCharacterTables.nesum(s[6], n, 1, q-2)
-6
With exceptions:
  a - b ∈ (q - 1)ℤ
  a + 2*b ∈ (q - 1)ℤ
  2*a + b ∈ (q - 1)ℤ
```
This looks reasonable if we remember the factor of $\frac{1}{2}$. The first parameter exception can never apply since it is explicitly stated in the description of the conjugacy class type 6:
```
julia> T[:,6]
Generic conjugacy class of SL3.n1
  with parameters
    a ∈ {1,…, q - 1}, b ∈ {1,…, q - 1} except a - b ∈ (q - 1)ℤ
  of order q^6 + 2*q^5 + 2*q^4 + q^3
  with values
    1: 1
    2: 2
    3: 1
    4: E(q - 1)^(a*n) + E(q - 1)^(b*n) + E(q - 1)^(-a*n - b*n)
    5: E(q - 1)^(a*n) + E(q - 1)^(b*n) + E(q - 1)^(-a*n - b*n)
    6: E(q - 1)^(-a*m - b*m + b*n) + E(q - 1)^(a*m - a*n - b*n) + E(q - 1)^(-a*n + b*m - b*n) + E(q - 1)^(-a*m + a*n - b*m) + E(q - 1)^(a*m + b*
    n) + E(q - 1)^(a*n + b*m)
    7: 0
    8: 0
```
But what about the other two exceptions? Unfortunately, we get a different result there:
```
julia> GenericCharacterTables.nesum(evaluate(s[6], [a], [-2*b]), n, 1, q-2)
2*q - 8
With exceptions:
  3*b ∈ (q - 1)ℤ
```
Checking the original [paper](https://doi.org/10.4153/CJM-1973-049-7) which introduced the table one can see that the class parameter description is missing a third parameter. In the paper the three parameters are called $k$, $l$, $m$. It is easy to see from the relations that $m \equiv_{q-1} -k-l$, hence the third parameter can be dropped. But what can't be dropped is the relation $k < l < m$. With the other relations this is equivalent to $k \not\equiv_{q-1} l$, $l \not\equiv_{q-1} m$ and $m \not\equiv_{q-1} k$. Without the third parameter this translates to the following forbidden relations (i.e. exceptions): $k - l \equiv_{q-1} 0$, $k + 2l \equiv_{q-1} 0$ and $l +2k \equiv_{q-1} 0$. Only the first was present in the table and the other two directly correspond to the exceptions from above. So, in fact the weird value of `2*q - 8` we computed above is invalid and does not correspond to a legal combination of parameters.

Similarly, the character type 6 was missing two exceptions as well.
