### PR TITLE
Fix doctests for AbstractAlgebra.jl >=0.49

### DIFF
--- a/src/GenericCyclotomics.jl
+++ b/src/GenericCyclotomics.jl
@@ -586,7 +586,7 @@ julia> S, E, q = generic_cyclotomic_ring()
 (Generic cyclotomic ring over Rational field, Generator of Generic cyclotomic ring over Rational field, q)
 
 julia> params(S, [:q, :i])
-2-element Vector{AbstractAlgebra.Generic.UnivPoly{QQFieldElem}}:
+2-element Vector{UniversalRingElem{QQMPolyRingElem, QQFieldElem}}:
  q
  i
 


### PR DESCRIPTION
As I've noticed in #321, even Oscar 1.5 uses a newer AbstractAlgebra version now which is incompatible with our current doctests.