### PR TITLE
Remove char and class parameter exceptions from results

### DIFF
--- a/docs/src/book.md
+++ b/docs/src/book.md
@@ -98,16 +98,13 @@ With exceptions:
   2*m1 - n1 ∈ (q - 1)ℤ
   m1 - 2*n1 ∈ (q - 1)ℤ
   m1 + n1 ∈ (q - 1)ℤ
-  m1 ∈ (q - 1)ℤ
   m1 - n1 ∈ (q - 1)ℤ
-  n1 ∈ (q - 1)ℤ
 <7, h> = 0
 With exceptions:
   n1 ∈ (q - 1)ℤ
 <8, h> = 0
 With exceptions:
   q*n1 ∈ (q^2 + q + 1)ℤ
-  n1 ∈ (q^2 + q + 1)ℤ
   q*n1 + n1 ∈ (q^2 + q + 1)ℤ
 ```
 

--- a/src/GenericCharacter.jl
+++ b/src/GenericCharacter.jl
@@ -320,7 +320,9 @@ function norm(char::GenericCharacter)
     val = char[class]
     sum += t.classlength[class] * classsum(t, class, val * conj(val))
   end
-  return shrink(sum//order(t))
+  result = shrink(sum//order(t))
+  remove_exceptions!(result, exceptions(parameters(char)))
+  return result
 end
 
 @doc raw"""
@@ -371,7 +373,10 @@ function scalar_product(char1::GenericCharacter, char2::GenericCharacter)
     val2 = shift_char_parameters(t, char2[class], 2)
     sum += t.classlength[class] * classsum(t, class, val1 * conj(val2))
   end
-  return shrink(sum//order(t))
+  result = shrink(sum//order(t))
+  remove_exceptions!(result, shift_char_parameters(t, exceptions(parameters(char1)), 1))
+  remove_exceptions!(result, shift_char_parameters(t, exceptions(parameters(char2)), 2))
+  return result
 end
 
 @doc raw"""

--- a/src/GenericConjugacyClasses.jl
+++ b/src/GenericConjugacyClasses.jl
@@ -134,8 +134,6 @@ julia> g=generic_character_table("SL2.0");
 
 julia> class_multiplication_coefficient(conjugacy_class_type(g, 2), conjugacy_class_type(g, 2), conjugacy_class_type(g, 4))
 q + 1
-With exceptions:
-  a3 ∈ (q + 1)ℤ
 ```
 """
 function class_multiplication_coefficient(
@@ -153,7 +151,11 @@ function class_multiplication_coefficient(
     val3 = shift_class_parameters(t, class3[i], 3)
     sum += charsum(char, val1 * val2 * conj(val3))//degree(char)
   end
-  return shrink((order(class1) * order(class2)) * sum//order(t))
+  result = shrink((order(class1) * order(class2)) * sum//order(t))
+  remove_exceptions!(result, shift_class_parameters(t, exceptions(parameters(class1)), 1))
+  remove_exceptions!(result, shift_class_parameters(t, exceptions(parameters(class2)), 2))
+  remove_exceptions!(result, shift_class_parameters(t, exceptions(parameters(class3)), 3))
+  return result
 end
 
 @doc raw"""
@@ -195,8 +197,6 @@ julia> g=generic_character_table("SL2.0");
 
 julia> class_multiplication_coefficient(g,2,2,4)
 q + 1
-With exceptions:
-  a3 ∈ (q + 1)ℤ
 ```
 """
 function class_multiplication_coefficient(
@@ -229,7 +229,9 @@ function norm(class::GenericConjugacyClass)
     val = class[i]
     sum += charsum(char, val * conj(val))
   end
-  return shrink((order(class) * sum)//order(t))
+  result = shrink((order(class) * sum)//order(t))
+  remove_exceptions!(result, exceptions(parameters(class)))
+  return result
 end
 
 @doc raw"""
@@ -289,7 +291,10 @@ function scalar_product(class1::GenericConjugacyClass, class2::GenericConjugacyC
     val2 = shift_class_parameters(t, class2[i], 2)
     sum += charsum(char, val1 * conj(val2))
   end
-  return shrink((order(class1) * sum)//order(t))
+  result = shrink((order(class1) * sum)//order(t))
+  remove_exceptions!(result, shift_class_parameters(t, exceptions(parameters(class1)), 1))
+  remove_exceptions!(result, shift_class_parameters(t, exceptions(parameters(class2)), 2))
+  return result
 end
 
 @doc raw"""

--- a/src/GenericCyclotomicFractions.jl
+++ b/src/GenericCyclotomicFractions.jl
@@ -2,8 +2,12 @@ function add_exception!(a::GenericCycloFrac, exception::UPolyFrac)
   add_exception!(a.exceptions, exception)
 end
 
+function remove_exceptions!(a::GenericCycloFrac, exceptions::ParameterExceptions)
+  remove_exceptions!(a.exceptions, exceptions)
+end
+
 @doc raw"""
-    shrink(a::GenericCycloFrac{<:NfPoly})
+    shrink(a::GenericCycloFrac{<:NfPoly}, exceptions::ParameterExceptions)
 
 Try to simplify the representation of `a`.
 """

--- a/src/Parameter.jl
+++ b/src/Parameter.jl
@@ -2,6 +2,8 @@ show(io::IO, a::Parameter) = print(io, "$(a.var) ∈ {1,…, $(a.modulus)}")
 
 show(io::IO, a::ParameterSubstitution) = print(io, "$(a.var) = $(a.expression)")
 
+exceptions(a::Parameters) = ParameterExceptions(a.exceptions)
+
 getindex(p::Parameters, i::Integer) = p.params[i]
 
 eltype(::Type{Parameters}) = Parameter

--- a/src/ParameterExceptions.jl
+++ b/src/ParameterExceptions.jl
@@ -41,6 +41,15 @@ function add_exception!(a::ParameterExceptions, exception::UPolyFrac)
 end
 
 @doc raw"""
+    remove_exceptions!(a::ParameterExceptions, b::ParameterExceptions)
+
+Remove the exceptions in `b` from `a`.
+"""
+function remove_exceptions!(a::ParameterExceptions, b::ParameterExceptions)
+  setdiff!(a.exceptions, b.exceptions)
+end
+
+@doc raw"""
     merge(x::ParameterExceptions, y::ParameterExceptions)
 
 Return a new collection of parameter exceptions composed of `x` and `y` where all redundant exceptions are omitted.

--- a/src/Shifts.jl
+++ b/src/Shifts.jl
@@ -34,29 +34,33 @@ function var_shift(a::Parameters, vars::Vector{Int64}, step_size::Int64, steps::
   return Parameters(var_shift.(a.params, Ref(vars), Ref(step_size), Ref(steps)),
     var_shift.(a.exceptions, Ref(vars), Ref(step_size), Ref(steps)))
 end
+function var_shift(a::ParameterExceptions, vars::Vector{Int64}, step_size::Int64, steps::Int64)
+  isempty(a.exceptions) && return a
+  return evaluate(a, vars, get_shift_mask(parent(numerator(a.exceptions[1])), vars, step_size, steps))
+end
 
 @doc raw"""
-    shift_class_parameters(t::CharTable, a::Union{Parameters,GenericCyclo,GenericCycloFrac}, steps::Int64)
+    shift_class_parameters(t::CharTable, a::Union{Parameters,ParameterExceptions,GenericCyclo,GenericCycloFrac}, steps::Int64)
 
 Replace all class parameters of `t` in `a` by their counterparts suffixed with `steps`.
 
 This is done by shifting them `steps*number_of_parameters(t)` steps further in `t.ring`.
 """
 function shift_class_parameters(
-  t::CharTable, a::Union{Parameters,GenericCyclo,GenericCycloFrac}, steps::Int64
+  t::CharTable, a::Union{Parameters,ParameterExceptions,GenericCyclo,GenericCycloFrac}, steps::Int64
 )
   return var_shift(a, t.classparamindex, number_of_parameters(t), steps)
 end
 
 @doc raw"""
-    shift_char_parameters(t::CharTable, a::Union{Parameters,GenericCyclo,GenericCycloFrac}, steps::Int64)
+    shift_char_parameters(t::CharTable, a::Union{Parameters,ParameterExceptions,GenericCyclo,GenericCycloFrac}, steps::Int64)
 
 Replace all character parameters of `t` in `a` by their counterparts suffixed with `steps`.
 
 This is done by shifting them `steps*number_of_parameters(t)` steps further in `t.ring`.
 """
 function shift_char_parameters(
-  t::CharTable, a::Union{Parameters,GenericCyclo,GenericCycloFrac}, steps::Int64
+  t::CharTable, a::Union{Parameters,ParameterExceptions,GenericCyclo,GenericCycloFrac}, steps::Int64
 )
   return var_shift(a, t.charparamindex, number_of_parameters(t), steps)
 end


### PR DESCRIPTION
While working through scalar products with many exceptions, I noticed that quite a few of them were exceptions which are already exceptions of the involved characters. Hence, they can't occur and we can just remove them from the result to make it more readable.

@fingolfin Unfortunately, this changes the book example again...