### PR TITLE
Improve `specialize` for characters and fix `evaluate` for exceptions

### DIFF
--- a/docs/src/book.md
+++ b/docs/src/book.md
@@ -98,7 +98,6 @@ With exceptions:
   2*m1 - n1 ∈ (q - 1)ℤ
   m1 - 2*n1 ∈ (q - 1)ℤ
   m1 + n1 ∈ (q - 1)ℤ
-  m1 - n1 ∈ (q - 1)ℤ
 <7, h> = 0
 With exceptions:
   n1 ∈ (q - 1)ℤ

--- a/src/GenericCharacter.jl
+++ b/src/GenericCharacter.jl
@@ -50,7 +50,7 @@ function tensor_product(char1::GenericCharacter, char2::GenericCharacter)
   param1 = shift_char_parameters(t, char1.params, 4)
   param2 = shift_char_parameters(t, char2.params, 5)
   new_char_params = Parameters(
-    vcat(param1.params, param2.params), vcat(param1.exceptions, param2.exceptions)
+    vcat(param1.params, param2.params), ParameterExceptions(vcat(param1.exceptions.exceptions, param2.exceptions.exceptions))
   )
   return GenericCharacter(
     t,
@@ -237,7 +237,7 @@ function linear_combination(coeffs::Vector{<:RingElement}, chars::Vector{<:Gener
     params[i] = shift_char_parameters(t, chars[i].params, 5 + i)
   end
   new_char_params = Parameters(
-    vcat(map(x -> x.params, params)...), vcat(map(x -> x.exceptions, params)...)
+    vcat(map(x -> x.params, params)...), ParameterExceptions(vcat(map(x -> x.exceptions.exceptions, params)...))
   )
   return GenericCharacter(
     t,
@@ -445,11 +445,26 @@ function specialize(char::GenericCharacter, var::UPoly, expr::RingElement)
   for class in 1:number_of_conjugacy_class_types(t)
     new_char_values[class] = evaluate(char[class], [var_index(var)], [expr])
   end
+  params = Parameters(Parameter[], evaluate(exceptions(parameters(char)), [var_index(var)], [expr]))
+  found_var = false
+  for param in parameters(char)
+    if var == param.var
+      found_var = true
+      c = coeff(expr, var)
+      if !iszero(c)
+        push!(params.params, Parameter(var, divexact(param.modulus, c)))
+      end
+    else
+      push!(params.params, param)
+    end
+  end
   substitutions = deepcopy(char.substitutions)
-  push!(substitutions, ParameterSubstitution(var, base_ring(t.ring)(expr)))
+  if !found_var
+    push!(substitutions, ParameterSubstitution(var, base_ring(t.ring)(expr)))
+  end
   # TODO: What about the sum function here?
   return GenericCharacter(
-    t, new_char_values, char.info, degree(char), nothing, char.params, substitutions
+    t, new_char_values, char.info, degree(char), nothing, params, substitutions
   )
 end
 

--- a/src/GenericCharacter.jl
+++ b/src/GenericCharacter.jl
@@ -450,7 +450,7 @@ function specialize(char::GenericCharacter, var::UPoly, expr::RingElement)
   for param in parameters(char)
     if var == param.var
       found_var = true
-      c = coeff(expr, var)
+      c = coeff(expr, [var], [1])
       if !iszero(c)
         push!(params.params, Parameter(var, divexact(param.modulus, c)))
       end

--- a/src/Parameter.jl
+++ b/src/Parameter.jl
@@ -2,7 +2,7 @@ show(io::IO, a::Parameter) = print(io, "$(a.var) ∈ {1,…, $(a.modulus)}")
 
 show(io::IO, a::ParameterSubstitution) = print(io, "$(a.var) = $(a.expression)")
 
-exceptions(a::Parameters) = ParameterExceptions(a.exceptions)
+exceptions(a::Parameters) = a.exceptions
 
 getindex(p::Parameters, i::Integer) = p.params[i]
 

--- a/src/ParameterExceptions.jl
+++ b/src/ParameterExceptions.jl
@@ -1,3 +1,12 @@
+getindex(exceptions::ParameterExceptions, i::Integer) = exceptions.exceptions[i]
+
+eltype(::Type{ParameterExceptions}) = UPolyFrac
+
+length(exceptions::ParameterExceptions) = length(exceptions.exceptions)
+
+iterate(exceptions::ParameterExceptions, state::Integer=1) =
+  state > length(exceptions) ? nothing : (exceptions[state], state + 1)
+
 @doc raw"""
     is_integer(x::UPolyFrac)
 
@@ -69,16 +78,16 @@ end
 
 Return if `x` actually restricts something.
 """
-is_restriction(x::ParameterExceptions) = !isempty(x.exceptions)
+is_restriction(x::ParameterExceptions) = !isempty(x)
 
 function show(io::IO, x::ParameterExceptions)
-  for (i, exception) in enumerate(x.exceptions)
+  for (i, exception) in enumerate(x)
     if isone(denominator(exception))
       print(io, "$(numerator(exception)) ∈ ℤ")
     else
       print(io, "$(numerator(exception)) ∈ ($(denominator(exception)))ℤ")
     end
-    if i < length(x.exceptions)
+    if i < length(x)
       print(io, "\n")
     end
   end
@@ -87,6 +96,9 @@ end
 # evaluate
 
 function evaluate(x::ParameterExceptions, vars::Vector{Int64}, vals::Vector{<:RingElement})
-  exceptions = evaluate.(x.exceptions, Ref(vars), Ref(vals))
-  return ParameterExceptions(exceptions)
+  exceptions = parameter_exceptions()
+  for exception in x
+    add_exception!(exceptions, evaluate(exception, vars, vals))
+  end
+  return exceptions
 end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -58,7 +58,7 @@ end
 @doc raw"""
     ParameterExceptions
 
-A collection of parameter exceptions used in `GenericCycloFrac`.
+A collection of parameter exceptions which describes illegal parameter combinations.
 """
 struct ParameterExceptions
   exceptions::Vector{UPolyFrac}
@@ -142,7 +142,10 @@ Parameters of generic characters and class types. This is used in `GenericCharac
 """
 struct Parameters
   params::Vector{Parameter}
-  exceptions::Vector{UPolyFrac}
+  exceptions::ParameterExceptions
+end
+function Parameters(params::Vector{Parameter}, exceptions::Vector{UPolyFrac})
+  return Parameters(params, ParameterExceptions(exceptions))
 end
 
 abstract type Table end


### PR DESCRIPTION
Especially with #324 it is quite helpful to have the parameters and exceptions of characters updated when specializing. This reduces the manual work necessary to go through the remaining exceptions when computing scalar products.